### PR TITLE
Fix/t type persistence

### DIFF
--- a/.github/DESIGN.md
+++ b/.github/DESIGN.md
@@ -615,18 +615,33 @@ $$
 This is a pure index swap. No conjugation is involved, even for complex entries.
 For the conjugate transpose, see Section 5.7.
 
-**Implementation.** `.T` is inherited from `np.ndarray` — it is the standard NumPy
-transpose attribute (a view, not a copy). No override is needed. The `__array_wrap__`
-logic (Section 4.4) determines the output type based on the resulting shape.
+**Implementation.** `.T` is a property on `_VecBase` that returns a transposed
+view with the subclass label dispatched by Section 4.4's shape → type rules. An
+explicit override is required because NumPy's native `.T` preserves the source
+subclass label rather than relabeling by shape. The method spelling
+`.transpose()` (and, by extension, `np.transpose(x)`) is overridden on
+`_VecBase` for the same reason, so all three spellings agree.
+
+```python
+# On _VecBase:
+@property
+def T(self):
+    return _apply_type_rules(np.asarray(self).transpose())
+
+def transpose(self, *axes):
+    return _apply_type_rules(np.asarray(self).transpose(*axes))
+```
 
 **Behavioural contract:**
 
 | Expression | Input type | Input shape | Output type | Output shape | Rationale |
 |---|---|---|---|---|---|
-| `u.T` | `ColVec` | $(n, 1)$, $n > 1$ | `Mat` | $(1, n)$ | A $(1 \times n)$ matrix is a row matrix, not a column vector |
-| `u.T` | `ColVec` | $(1, 1)$ | `ColVec` | $(1, 1)$ | A $(1 \times 1)$ matrix has one column → `ColVec` by Section 4.4 rules |
-| `A.T` | `Mat` | $(n, k)$, $k > 1$ | `Mat` | $(k, n)$ | Transpose of a matrix is a matrix |
-| `A.T` | `Mat` | $(n, 1)$ | `Mat` | $(1, n)$ | Single-column `Mat` transposed → row matrix |
+| `u.T` | `ColVec` | $(n, 1)$, $n > 1$ | `Mat` | $(1, n)$ | Output has $>1$ column → `Mat` by Section 4.4 |
+| `u.T` | `ColVec` | $(1, 1)$ | `ColVec` | $(1, 1)$ | Output is $(n, 1)$ → `ColVec` by Section 4.4 |
+| `A.T` | `Mat` | $(n, k)$, $n > 1, k > 1$ | `Mat` | $(k, n)$ | Output has $>1$ column → `Mat` by Section 4.4 |
+| `A.T` | `Mat` | $(n, 1)$, $n > 1$ | `Mat` | $(1, n)$ | Output has $>1$ column → `Mat` by Section 4.4 |
+| `A.T` | `Mat` | $(1, k)$, $k > 1$ | `ColVec` | $(k, 1)$ | Output is $(n, 1)$ → `ColVec` by Section 4.4 |
+| `A.T` | `Mat` | $(1, 1)$ | `ColVec` | $(1, 1)$ | Output is $(n, 1)$ → `ColVec` by Section 4.4 |
 
 **Key points:**
 - `.T` is always a **view** (no data copy). Modifications to `u.T` modify `u`.

--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -104,7 +104,7 @@ class _VecBase(np.ndarray):
 
         Returns
         -------
-        ColVec or Mat or np.ndarray
+        ColVec or Mat
             Type determined by output shape per §4.4.
         """
         return _apply_type_rules(np.asarray(self).transpose(*axes))

--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -78,6 +78,37 @@ class _VecBase(np.ndarray):
 
             return _apply_type_rules(results)
 
+    @property
+    def T(self):
+        """Transpose, with subclass label dispatched by output shape.
+
+        Returns a view of the underlying data with axes reversed. The
+        class label follows §4.4 shape → type rules: shape (n, 1) →
+        ColVec; any other 2D shape → Mat. Shadows np.ndarray.T because
+        NumPy sets the view's shape after __array_finalize__ returns,
+        so the inherited .T would otherwise keep the source subclass.
+
+        Returns
+        -------
+        ColVec or Mat
+            Type determined by output shape per §4.4.
+        """
+        return _apply_type_rules(np.asarray(self).transpose())
+
+    def transpose(self, *axes):
+        """Transpose, with subclass label dispatched by output shape.
+
+        Semantic twin of `.T` covering the method spelling (and, by
+        extension, `np.transpose(x)`). The returned class label follows
+        §4.4 shape → type rules.
+
+        Returns
+        -------
+        ColVec or Mat or np.ndarray
+            Type determined by output shape per §4.4.
+        """
+        return _apply_type_rules(np.asarray(self).transpose(*axes))
+
 
 class ColVec(_VecBase):
     """Column vector: shape (n, 1), dtype float64.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,6 +56,26 @@
 - Source: DESIGN.md §4.4 — "For 0D or 1D results (reductions, scalar outputs),
           return plain ndarray".
 - Expected: np.sum(colvec) is a plain scalar (not _VecBase subclass).
+
+## Test: test_t_property_yields_correct_subtype
+- Goal: Verify that `.T` on a _VecBase subclass returns a view whose class
+        label follows the §4.4 shape → type rules (shape (n,1) → ColVec;
+        any other 2D shape → Mat).
+- Source: DESIGN.md §5.6 table — "u.T on ColVec (n,1), n>1 → Mat (1,n);
+          u.T on ColVec (1,1) → ColVec (1,1); A.T on Mat (n,k) → Mat (k,n);
+          A.T on Mat (n,1) → Mat (1,n) [but §4.4 routes (1,n) to Mat, (n,1)
+          to ColVec]".
+- Expected: ColVec(3,1).T → Mat(1,3); ColVec(1,1).T → ColVec(1,1);
+            Mat(3,2).T → Mat(2,3); Mat(1,3).T → ColVec(3,1). Values equal
+            np.asarray(x).T elementwise.
+
+## Test: test_transpose_method_consistent_with_t_attribute
+- Goal: Verify that `.transpose()` (and by extension np.transpose(x)) returns
+        the same type and shape as `.T` for every _VecBase subclass instance.
+- Source: DESIGN.md §5.6 — `.T` and `.transpose()` are semantically equivalent
+          operations; both must honour §4.4.
+- Expected: for each of the four shape cases, type(arr.transpose()) and
+            type(np.transpose(arr)) equal type(arr.T); shapes match.
 """
 
 import numpy as np
@@ -142,3 +162,46 @@ class TestUfuncPersistence:
         s = np.sum(u)
         assert not isinstance(s, ColVec)
         assert not isinstance(s, Mat)
+
+
+class TestTransposeTypePersistence:
+    @pytest.mark.parametrize(
+        "input_array, expected_type, expected_shape",
+        [
+            (np.array([[1.0], [2.0], [3.0]]), Mat, (1, 3)),
+            (np.array([[5.0]]), ColVec, (1, 1)),
+            (np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]), Mat, (2, 3)),
+            (np.array([[1.0, 2.0, 3.0]]), ColVec, (3, 1)),
+        ],
+    )
+    def test_t_property_yields_correct_subtype(
+        self, input_array, expected_type, expected_shape
+    ):
+        """`.T` relabels the view per §4.4 shape → type rules."""
+        source_type = ColVec if input_array.shape[1] == 1 else Mat
+        arr = source_type(input_array)
+        result = arr.T
+        assert isinstance(result, expected_type)
+        assert result.shape == expected_shape
+        assert np.array_equal(np.asarray(result), np.asarray(arr).T)
+
+    @pytest.mark.parametrize(
+        "input_array",
+        [
+            np.array([[1.0], [2.0], [3.0]]),
+            np.array([[5.0]]),
+            np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+            np.array([[1.0, 2.0, 3.0]]),
+        ],
+    )
+    def test_transpose_method_consistent_with_t_attribute(self, input_array):
+        """`.transpose()` and `np.transpose(x)` match `.T` in type and shape."""
+        source_type = ColVec if input_array.shape[1] == 1 else Mat
+        arr = source_type(input_array)
+        via_attr = arr.T
+        via_method = arr.transpose()
+        via_module = np.transpose(arr)
+        assert type(via_method) is type(via_attr)
+        assert via_method.shape == via_attr.shape
+        assert type(via_module) is type(via_attr)
+        assert via_module.shape == via_attr.shape

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,10 +72,20 @@
 ## Test: test_transpose_method_consistent_with_t_attribute
 - Goal: Verify that `.transpose()` (and by extension np.transpose(x)) returns
         the same type and shape as `.T` for every _VecBase subclass instance.
-- Source: DESIGN.md §5.6 — `.T` and `.transpose()` are semantically equivalent
-          operations; both must honour §4.4.
-- Expected: for each of the four shape cases, type(arr.transpose()) and
+- Source: DESIGN.md §5.6 defines the `.T` result shapes/types, and §4.4
+          defines the 2D shape → subtype routing; `.transpose()` and
+          np.transpose(x) are checked here for consistency with the inherited
+          NumPy transpose API.
+- Expected: for each parametrised case, type(arr.transpose()) and
             type(np.transpose(arr)) equal type(arr.T); shapes match.
+
+## Test: test_t_is_a_view
+- Goal: Verify that `.T` returns a view, not a copy — mutating the transpose
+        mutates the source and vice versa.
+- Source: DESIGN.md §5.6 — "`.T` is always a view (no data copy). Modifications
+          to u.T modify u."
+- Expected: np.shares_memory(arr.T, arr) is True, and writing to arr.T propagates
+            back to arr.
 """
 
 import numpy as np
@@ -166,19 +176,19 @@ class TestUfuncPersistence:
 
 class TestTransposeTypePersistence:
     @pytest.mark.parametrize(
-        "input_array, expected_type, expected_shape",
+        "source_type, input_array, expected_type, expected_shape",
         [
-            (np.array([[1.0], [2.0], [3.0]]), Mat, (1, 3)),
-            (np.array([[5.0]]), ColVec, (1, 1)),
-            (np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]), Mat, (2, 3)),
-            (np.array([[1.0, 2.0, 3.0]]), ColVec, (3, 1)),
+            (ColVec, np.array([[1.0], [2.0], [3.0]]), Mat, (1, 3)),
+            (ColVec, np.array([[5.0]]), ColVec, (1, 1)),
+            (Mat, np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]), Mat, (2, 3)),
+            (Mat, np.array([[1.0, 2.0, 3.0]]), ColVec, (3, 1)),
+            (Mat, np.array([[1.0], [2.0], [3.0]]), Mat, (1, 3)),
         ],
     )
     def test_t_property_yields_correct_subtype(
-        self, input_array, expected_type, expected_shape
+        self, source_type, input_array, expected_type, expected_shape
     ):
         """`.T` relabels the view per §4.4 shape → type rules."""
-        source_type = ColVec if input_array.shape[1] == 1 else Mat
         arr = source_type(input_array)
         result = arr.T
         assert isinstance(result, expected_type)
@@ -186,17 +196,19 @@ class TestTransposeTypePersistence:
         assert np.array_equal(np.asarray(result), np.asarray(arr).T)
 
     @pytest.mark.parametrize(
-        "input_array",
+        "source_type, input_array",
         [
-            np.array([[1.0], [2.0], [3.0]]),
-            np.array([[5.0]]),
-            np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
-            np.array([[1.0, 2.0, 3.0]]),
+            (ColVec, np.array([[1.0], [2.0], [3.0]])),
+            (ColVec, np.array([[5.0]])),
+            (Mat, np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])),
+            (Mat, np.array([[1.0, 2.0, 3.0]])),
+            (Mat, np.array([[1.0], [2.0], [3.0]])),
         ],
     )
-    def test_transpose_method_consistent_with_t_attribute(self, input_array):
+    def test_transpose_method_consistent_with_t_attribute(
+        self, source_type, input_array
+    ):
         """`.transpose()` and `np.transpose(x)` match `.T` in type and shape."""
-        source_type = ColVec if input_array.shape[1] == 1 else Mat
         arr = source_type(input_array)
         via_attr = arr.T
         via_method = arr.transpose()
@@ -205,3 +217,11 @@ class TestTransposeTypePersistence:
         assert via_method.shape == via_attr.shape
         assert type(via_module) is type(via_attr)
         assert via_module.shape == via_attr.shape
+
+    def test_t_is_a_view(self):
+        """`.T` shares memory with the source; mutations propagate both ways."""
+        arr = Mat(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        t = arr.T
+        assert np.shares_memory(np.asarray(t), np.asarray(arr))
+        t[0, 1] = 99.0
+        assert arr[1, 0] == 99.0


### PR DESCRIPTION
This pull request adds support for correct type relabeling when transposing custom matrix and vector subclasses, and introduces comprehensive tests to verify this behavior. The main focus is ensuring that the `.T` property and `.transpose()` method on `ColVec` and `Mat` subclasses return instances with the appropriate subclass label according to the shape-to-type rules defined in the design specification.

Type relabeling and transpose support:

* Added a `.T` property and a `.transpose()` method to the `_VecBase` class in `nemopy/_core.py`, both of which return a view of the data with axes reversed and the subclass label determined by the output shape as per §4.4 shape-to-type rules. This ensures that transposing a `ColVec` or `Mat` instance yields the correct subclass, addressing NumPy's default behavior which does not relabel subclasses after transpose.

Testing improvements:

* Added detailed tests in `tests/test_core.py` to verify that the `.T` property and `.transpose()` method on `ColVec` and `Mat` instances return the correct subclass and shape. Tests also check that `np.transpose(x)` matches the behavior of `.T` and `.transpose()` for all relevant shape cases. [[1]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058R59-R78) [[2]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058R165-R207)