### PR TITLE
feat(core): add .H conjugate transpose property on _VecBase (TASK-01)

### DIFF
--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -109,6 +109,19 @@ class _VecBase(np.ndarray):
         """
         return _apply_type_rules(np.asarray(self).transpose(*axes))
 
+    @property
+    def H(self):
+        """Conjugate transpose (Hermitian adjoint).
+
+        Returns self.conj().T. For real arrays, this is identical to .T.
+
+        Returns
+        -------
+        ColVec or Mat
+            Type determined by output shape (same rules as .T).
+        """
+        return self.conj().T
+
 
 class ColVec(_VecBase):
     """Column vector: shape (n, 1), dtype float64.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,4 +269,6 @@ class TestConjugateTranspose:
         arr = raw.view(Mat)
         result = arr.H
         expected = np.conj(raw).T
+        assert isinstance(result, Mat)
+        assert result.shape == (2, 3)
         assert np.array_equal(np.asarray(result), expected)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -86,6 +86,21 @@
           to u.T modify u."
 - Expected: np.shares_memory(arr.T, arr) is True, and writing to arr.T propagates
             back to arr.
+
+## Test: test_h_real_inputs_match_transpose_elementwise_and_type
+- Goal: Verify that .H on a real _VecBase equals .T elementwise and that
+        the resulting type follows §4.4 persistence rules (shape (n,1) → ColVec;
+        any other 2D shape → Mat).
+- Source: DESIGN.md §5.7 — "Returns self.conj().T. For real arrays, this is
+          identical to .T" + §4.4 type-persistence table.
+- Expected: For ColVec(3,1) → Mat(1,3); ColVec(1,1) → ColVec(1,1);
+            Mat(3,2) → Mat(2,3); Mat(1,3) → ColVec(3,1). Values equal .T.
+
+## Test: test_h_complex_elements_are_conjugated
+- Goal: Verify that for complex input .H conjugates elements (the only
+        behavioural difference from .T).
+- Source: DESIGN.md §5.7 — mathematical definition (A^H)_ij = conj(A_ji).
+- Expected: A.H values equal np.conj(A).T values elementwise.
 """
 
 import numpy as np
@@ -225,3 +240,33 @@ class TestTransposeTypePersistence:
         assert np.shares_memory(np.asarray(t), np.asarray(arr))
         t[0, 1] = 99.0
         assert arr[1, 0] == 99.0
+
+
+class TestConjugateTranspose:
+    @pytest.mark.parametrize(
+        "input_array, expected_type, expected_shape",
+        [
+            (np.array([[1.0], [2.0], [3.0]]), Mat, (1, 3)),
+            (np.array([[5.0]]), ColVec, (1, 1)),
+            (np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]), Mat, (2, 3)),
+            (np.array([[1.0, 2.0, 3.0]]), ColVec, (3, 1)),
+        ],
+    )
+    def test_h_real_inputs_match_transpose_elementwise_and_type(
+        self, input_array, expected_type, expected_shape
+    ):
+        """For real inputs, .H equals .T and result type follows §4.4."""
+        source_type = ColVec if input_array.shape[1] == 1 else Mat
+        arr = source_type(input_array)
+        result = arr.H
+        assert isinstance(result, expected_type)
+        assert result.shape == expected_shape
+        assert np.array_equal(np.asarray(result), np.asarray(arr.T))
+
+    def test_h_complex_elements_are_conjugated(self):
+        """For complex input, .H conjugates elements (distinguishes from .T)."""
+        raw = np.array([[1 + 2j, 3 - 1j], [0 + 0j, 4 + 5j], [2 - 3j, -1 + 1j]])
+        arr = raw.view(Mat)
+        result = arr.H
+        expected = np.conj(raw).T
+        assert np.array_equal(np.asarray(result), expected)


### PR DESCRIPTION
## Summary
- Adds the `.H` conjugate-transpose (Hermitian adjoint) property to `_VecBase`, implemented verbatim as specified in DESIGN.md §5.7: `return self.conj().T`.
- Inherited by both `ColVec` and `Mat`. For real arrays `.H == .T`; for complex arrays `.H` conjugates then transposes.
- Result subclass follows §4.4 shape → type rules (inherited from the `.T` dispatch shipped in PR #9).

## Spec trace
- DESIGN.md §5.7 (`.H` property) — implementation, docstring, and decorator match the spec code block exactly.
- Appendix B line 826 — verification item covered.

## Assumptions
- `.H` is defined only on `_VecBase`, not separately on `ColVec`/`Mat` (spec places it on the base class).
- Complex-dtype arrays are constructed via `raw.view(Mat)` in the test because `ColVec.__new__` / `Mat.__new__` force `dtype=float`. Constructor behaviour for complex inputs is out of scope for TASK-01.

## Test plan
- [x] `test_h_real_inputs_match_transpose_elementwise_and_type` — parametrised over the four §5.6 shape cases; asserts `arr.H` matches `arr.T` value-wise and that the result type follows §4.4.
- [x] `test_h_complex_elements_are_conjugated` — complex 3×2 input; asserts `arr.H` equals `np.conj(raw).T` elementwise (the only behaviour that distinguishes `.H` from `.T`).
- [x] Full suite: `pytest tests/` — 39 passed.

Closes TASK-01.