### PR TITLE
feat(core): add ColVec.__getitem__ override (TASK-02)

### DIFF
--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -145,6 +145,37 @@ class ColVec(_VecBase):
     def __str__(self):
         return self.__repr__()
 
+    def __getitem__(self, key):
+        """Index a ColVec, enforcing column-vector semantics per §6.1.
+
+        Single-element extraction (integer or (i, 0) tuple) returns a Python
+        float; structure-preserving indexing (slice, fancy, boolean mask)
+        returns a ColVec of shape (k, 1).
+
+        Returns
+        -------
+        float, ColVec, or np.ndarray
+            Type determined by the shape of the underlying indexing result.
+        """
+        if self.ndim != 2 or self.shape[1] != 1:
+            return np.asarray(self)[key]
+
+        result = super().__getitem__(key)
+
+        if not isinstance(result, np.ndarray) or result.ndim == 0:
+            return float(result)
+
+        if result.ndim == 1 and result.size == 1:
+            return float(result[0])
+
+        if result.ndim == 1:
+            return ColVec(result.reshape(-1, 1))
+
+        if result.ndim == 2 and result.shape[1] == 1:
+            return result.view(ColVec)
+
+        return np.asarray(result)
+
 
 class Mat(_VecBase):
     """Matrix: shape (n, k) with k >= 1, dtype float64.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -101,6 +101,37 @@
         behavioural difference from .T).
 - Source: DESIGN.md §5.7 — mathematical definition (A^H)_ij = conj(A_ji).
 - Expected: A.H values equal np.conj(A).T values elementwise.
+
+## Test: test_int_index_returns_scalar_float
+- Goal: Verify that integer indexing on a ColVec returns a Python float equal
+        to the extracted element.
+- Source: DESIGN.md §6.1 table row 1 — "u[0] → np.float64, scalar 10.0";
+          §6.1 narrative — "u[0] returns a scalar, not a (1, 1) ColVec".
+- Expected: u[0] is a float (via isinstance) and equals 10.0.
+
+## Test: test_tuple_index_returns_scalar_float
+- Goal: Verify that explicit 2D indexing (u[i, 0]) on a ColVec returns a
+        Python float equal to the extracted element.
+- Source: DESIGN.md §6.1 table row 2 — "u[0, 0] → np.float64, scalar 10.0".
+- Expected: u[0, 0] is a float and equals 10.0.
+
+## Test: test_slice_returns_colvec
+- Goal: Verify that slicing a ColVec preserves column structure, returning a
+        ColVec of shape (k, 1) with the expected values.
+- Source: DESIGN.md §6.1 table row 3 — "u[1:4] → ColVec, shape (3, 1)".
+- Expected: u[1:4] is a ColVec of shape (3, 1) with values [20, 30, 40].
+
+## Test: test_fancy_index_returns_colvec
+- Goal: Verify that fancy indexing (list of ints) on a ColVec preserves column
+        structure, returning a ColVec.
+- Source: DESIGN.md §6.1 table row 4 — "u[[0, 2, 4]] → ColVec, shape (3, 1)".
+- Expected: u[[0, 2, 4]] is a ColVec of shape (3, 1) with values [10, 30, 50].
+
+## Test: test_boolean_mask_returns_colvec
+- Goal: Verify that boolean-mask indexing on a ColVec preserves column
+        structure, returning a ColVec.
+- Source: DESIGN.md §6.1 table row 5 — "u[u > 25] → ColVec, shape (3, 1)".
+- Expected: u[u > 25] is a ColVec of shape (3, 1) with values [30, 40, 50].
 """
 
 import numpy as np
@@ -272,3 +303,47 @@ class TestConjugateTranspose:
         assert isinstance(result, Mat)
         assert result.shape == (2, 3)
         assert np.array_equal(np.asarray(result), expected)
+
+
+class TestColVecGetitem:
+    @staticmethod
+    def _u():
+        return ColVec(np.array([[10.0], [20.0], [30.0], [40.0], [50.0]]))
+
+    def test_int_index_returns_scalar_float(self):
+        """u[0] returns a Python float equal to the first element."""
+        u = self._u()
+        result = u[0]
+        assert type(result) is float
+        assert result == 10.0
+
+    def test_tuple_index_returns_scalar_float(self):
+        """u[0, 0] returns a Python float equal to the first element."""
+        u = self._u()
+        result = u[0, 0]
+        assert type(result) is float
+        assert result == 10.0
+
+    def test_slice_returns_colvec(self):
+        """u[1:4] returns a ColVec of shape (3, 1) with the sliced values."""
+        u = self._u()
+        result = u[1:4]
+        assert isinstance(result, ColVec)
+        assert result.shape == (3, 1)
+        assert np.array_equal(np.asarray(result), np.array([[20.0], [30.0], [40.0]]))
+
+    def test_fancy_index_returns_colvec(self):
+        """u[[0, 2, 4]] returns a ColVec of shape (3, 1) with the selected values."""
+        u = self._u()
+        result = u[[0, 2, 4]]
+        assert isinstance(result, ColVec)
+        assert result.shape == (3, 1)
+        assert np.array_equal(np.asarray(result), np.array([[10.0], [30.0], [50.0]]))
+
+    def test_boolean_mask_returns_colvec(self):
+        """u[u > 25] returns a ColVec of shape (3, 1) with the matching values."""
+        u = self._u()
+        result = u[u > 25]
+        assert isinstance(result, ColVec)
+        assert result.shape == (3, 1)
+        assert np.array_equal(np.asarray(result), np.array([[30.0], [40.0], [50.0]]))


### PR DESCRIPTION
## Summary

Implements TASK-02 from `TASKS.md` — `ColVec.__getitem__` override per
`DESIGN.md` §6.1.

- Integer index (`u[0]`) and tuple index (`u[i, 0]`) return a Python `float`.
- Slice (`u[1:4]`), fancy (`u[[0, 2, 4]]`), and boolean-mask (`u[u > 25]`)
  indexing return a `ColVec` of shape `(k, 1)`.
- Five tests added (`TestColVecGetitem`), one per row of the §6.1 contract
  table, each with a stated goal traceable to the spec (per `CLAUDE.md`
  §6.1).

## Notes / assumptions

- TASK-01 (`.H` property) was verified complete (PR #10, merged) before
  starting this work.
- `DESIGN.md` §6.1 table/narrative and the §6.2 reference code disagree on
  what `u[0]` returns (table: scalar; reference code: `(1, 1)` ColVec). Per
  user direction, the §6.2 code block is illustrative and the §6.1
  behavioural contract wins. The override therefore collapses 1-D
  single-element results to `float`.
- Guard added: when `self` does not satisfy the `(n, 1)` invariant (e.g. a
  ColVec-labelled 1-D view produced by `.flatten()`), the override delegates
  to plain ndarray indexing. Without this guard, NumPy internals such as
  `np.testing.assert_array_compare` would receive `(k, 1)` arrays where they
  expect `(k,)`, breaking unrelated tests.
- Branch deviates from the `feat/colvec-getitem` convention in `TASKS.md`
  per user direction (reuse the existing `claude/...` branch rather than
  spinning up a throwaway).

## Test plan

- [x] `pytest tests/test_core.py::TestColVecGetitem` — all 5 tests pass.
- [x] `pytest` — full suite (44 tests) green; no regressions.
- [x] Red-green verified: 3 new tests fail before the override is added,
      pass after.
- [x] Cleanup Audit (`CLAUDE.md` §9) and Scope Test (§2.3) applied to the
      diff.