### PR TITLE
feat(constructors): add as_col inbound converter (TASK-12)

### DIFF
--- a/nemopy/__init__.py
+++ b/nemopy/__init__.py
@@ -1,12 +1,13 @@
 """nemopy — A column-vector-first NumPy wrapper."""
 
 from nemopy._core import ColVec, Mat, ShapeError, ConventionWarning  # noqa: F401
-from nemopy._constructors import _c, mat, eye  # noqa: F401
+from nemopy._constructors import _c, mat, eye, as_col  # noqa: F401
 
 __all__ = [
     "_c",
     "mat",
     "eye",
+    "as_col",
     "ColVec",
     "Mat",
     "ShapeError",

--- a/nemopy/_constructors.py
+++ b/nemopy/_constructors.py
@@ -143,7 +143,7 @@ def as_col(x):
     TypeError
         If ``x`` cannot be converted to a numeric array.
     """
-    if isinstance(x, (int, float, complex, np.generic)):
+    if isinstance(x, (int, float, np.generic)):
         return ColVec(np.array([[float(x)]]))
 
     try:
@@ -154,7 +154,13 @@ def as_col(x):
     except ImportError:
         pass
 
-    arr = np.asarray(x, dtype=float)
+    try:
+        arr = np.asarray(x, dtype=float)
+    except (ValueError, TypeError) as e:
+        raise TypeError(
+            f"as_col() could not convert input of type {type(x).__name__} "
+            f"to a numeric array."
+        ) from e
 
     if arr.ndim == 0:
         return ColVec(arr.reshape(1, 1))

--- a/nemopy/_constructors.py
+++ b/nemopy/_constructors.py
@@ -1,10 +1,10 @@
-"""Constructors: _c singleton, mat(), eye()."""
+"""Constructors: _c singleton, mat(), eye(), as_col()."""
 
 import warnings
 
 import numpy as np
 
-from nemopy._core import ColVec, ConventionWarning, Mat
+from nemopy._core import ColVec, ConventionWarning, Mat, ShapeError
 
 
 class _ColConstructor:
@@ -118,3 +118,56 @@ def eye(n):
         Shape ``(n, n)`` identity matrix with dtype ``float64``.
     """
     return Mat(np.eye(int(n)))
+
+
+def as_col(x):
+    """Convert any array-like to a ColVec.
+
+    Accepts 1D arrays, flat lists, pandas Series, (n,1) arrays, and
+    scalar values. Performs reshaping as needed.
+
+    Parameters
+    ----------
+    x : array-like
+        Input data. Must be convertible to a 1D or (n,1) numeric array.
+
+    Returns
+    -------
+    ColVec
+        Shape ``(n, 1)``.
+
+    Raises
+    ------
+    ShapeError
+        If ``x`` is 2D with more than one column (ambiguous — which column?).
+    TypeError
+        If ``x`` cannot be converted to a numeric array.
+    """
+    if isinstance(x, (int, float, complex, np.generic)):
+        return ColVec(np.array([[float(x)]]))
+
+    try:
+        import pandas as pd
+
+        if isinstance(x, pd.Series):
+            return ColVec(x.values.astype(float).reshape(-1, 1))
+    except ImportError:
+        pass
+
+    arr = np.asarray(x, dtype=float)
+
+    if arr.ndim == 0:
+        return ColVec(arr.reshape(1, 1))
+    if arr.ndim == 1:
+        return ColVec(arr.reshape(-1, 1))
+    if arr.ndim == 2 and arr.shape[1] == 1:
+        return ColVec(arr)
+    if arr.ndim == 2:
+        raise ShapeError(
+            f"as_col() received a 2D array with shape {arr.shape}. "
+            f"Cannot determine which column to extract. "
+            f"Pass a single column: as_col(arr[:, j])"
+        )
+    raise ShapeError(
+        f"as_col() requires a 1D or (n,1) input, got ndim={arr.ndim}."
+    )

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -52,12 +52,42 @@
 - Goal: Verify that eye(3) returns a Mat of shape (3, 3) with identity matrix values.
 - Source: DESIGN.md §5.8 — "return Mat(np.eye(int(n)))".
 - Expected: result is Mat, shape (3, 3), values match np.eye(3).
+
+## Test: test_as_col_from_list
+- Goal: Verify that as_col([1, 2, 3]) returns ColVec with shape (3, 1).
+- Source: DESIGN_APPENDICES.md §13.3 — as_col accepts flat lists and reshapes to (n,1).
+- Expected: result is ColVec, shape (3, 1), values [1.0, 2.0, 3.0].
+
+## Test: test_as_col_from_scalar
+- Goal: Verify that as_col(7) returns ColVec with shape (1, 1).
+- Source: DESIGN_APPENDICES.md §13.3 — as_col accepts scalar values and reshapes to (1,1).
+- Expected: result is ColVec, shape (1, 1), value 7.0.
+
+## Test: test_as_col_from_1d_ndarray
+- Goal: Verify that as_col(np.array([1, 2, 3])) returns ColVec with shape (3, 1).
+- Source: DESIGN_APPENDICES.md §13.3 — as_col accepts 1D ndarrays and reshapes to (n,1).
+- Expected: result is ColVec, shape (3, 1), values [1.0, 2.0, 3.0].
+
+## Test: test_as_col_from_2d_single_column_ndarray
+- Goal: Verify that as_col(np.ones((3, 1))) returns ColVec with shape (3, 1).
+- Source: DESIGN_APPENDICES.md §13.3 — as_col accepts (n,1) arrays directly.
+- Expected: result is ColVec, shape (3, 1), values are all ones.
+
+## Test: test_as_col_from_pandas_series_if_available
+- Goal: Verify that as_col(pd.Series([4, 5])) returns ColVec with shape (2, 1) when pandas is installed.
+- Source: DESIGN_APPENDICES.md §13.3 — as_col accepts pandas Series.
+- Expected: result is ColVec, shape (2, 1), values [4.0, 5.0].
+
+## Test: test_as_col_rejects_2d_multi_column
+- Goal: Verify that as_col(np.ones((3, 3))) raises ShapeError.
+- Source: DESIGN_APPENDICES.md §13.3 — 2D inputs with more than one column are rejected.
+- Expected: ShapeError raised.
 """
 
 import numpy as np
 import pytest
 
-from nemopy import _c, mat, eye, ColVec, Mat
+from nemopy import _c, as_col, mat, eye, ColVec, Mat, ShapeError
 
 
 class TestColConstructor:
@@ -127,3 +157,46 @@ class TestEyeConstructor:
         assert isinstance(I, Mat)
         assert I.shape == (3, 3)
         np.testing.assert_array_equal(np.asarray(I), np.eye(3))
+
+
+class TestAsColConverter:
+    def test_as_col_from_list(self):
+        """as_col([1, 2, 3]) returns ColVec with shape (3, 1)."""
+        u = as_col([1, 2, 3])
+        assert isinstance(u, ColVec)
+        assert u.shape == (3, 1)
+        np.testing.assert_array_equal(u.flatten(), [1.0, 2.0, 3.0])
+
+    def test_as_col_from_scalar(self):
+        """as_col(7) returns ColVec with shape (1, 1)."""
+        u = as_col(7)
+        assert isinstance(u, ColVec)
+        assert u.shape == (1, 1)
+        assert u.item() == 7.0
+
+    def test_as_col_from_1d_ndarray(self):
+        """as_col(np.array([1,2,3])) returns ColVec with shape (3, 1)."""
+        u = as_col(np.array([1, 2, 3]))
+        assert isinstance(u, ColVec)
+        assert u.shape == (3, 1)
+        np.testing.assert_array_equal(u.flatten(), [1.0, 2.0, 3.0])
+
+    def test_as_col_from_2d_single_column_ndarray(self):
+        """as_col(np.ones((3,1))) returns ColVec with shape (3, 1)."""
+        u = as_col(np.ones((3, 1)))
+        assert isinstance(u, ColVec)
+        assert u.shape == (3, 1)
+        np.testing.assert_array_equal(u.flatten(), [1.0, 1.0, 1.0])
+
+    def test_as_col_from_pandas_series_if_available(self):
+        """as_col(pd.Series([4,5])) returns ColVec (2,1) when pandas is installed."""
+        pd = pytest.importorskip("pandas")
+        u = as_col(pd.Series([4, 5]))
+        assert isinstance(u, ColVec)
+        assert u.shape == (2, 1)
+        np.testing.assert_array_equal(u.flatten(), [4.0, 5.0])
+
+    def test_as_col_rejects_2d_multi_column(self):
+        """as_col(np.ones((3,3))) raises ShapeError."""
+        with pytest.raises(ShapeError):
+            as_col(np.ones((3, 3)))

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -82,6 +82,13 @@
 - Goal: Verify that as_col(np.ones((3, 3))) raises ShapeError.
 - Source: DESIGN_APPENDICES.md §13.3 — 2D inputs with more than one column are rejected.
 - Expected: ShapeError raised.
+
+## Test: test_as_col_rejects_non_numeric_input
+- Goal: Verify that as_col raises TypeError (not ValueError) when the input
+        cannot be converted to a numeric array.
+- Source: DESIGN_APPENDICES.md §13.3 — documented TypeError contract for
+          non-numeric inputs.
+- Expected: TypeError raised for as_col(['a']).
 """
 
 import numpy as np
@@ -200,3 +207,8 @@ class TestAsColConverter:
         """as_col(np.ones((3,3))) raises ShapeError."""
         with pytest.raises(ShapeError):
             as_col(np.ones((3, 3)))
+
+    def test_as_col_rejects_non_numeric_input(self):
+        """as_col(['a']) raises TypeError per the documented contract."""
+        with pytest.raises(TypeError):
+            as_col(["a"])


### PR DESCRIPTION
## Summary

Implements **TASK-12** from `TASKS.md` — `as_col` inbound converter per `DESIGN_APPENDICES.md` §13.3.

- `as_col([1, 2, 3])` → `ColVec` of shape `(3, 1)`.
- `as_col(7)` → `ColVec` of shape `(1, 1)`.
- `as_col(np.array([1, 2, 3]))` → `ColVec` of shape `(3, 1)` (1D array accepted, unlike the bare `ColVec` constructor).
- `as_col(np.ones((3, 1)))` → `ColVec` of shape `(3, 1)`.
- `as_col(pd.Series([4, 5]))` → `ColVec` of shape `(2, 1)` when pandas is available.
- `as_col(np.ones((3, 3)))` raises `ShapeError`.
- `as_col` is added to `__all__` in `nemopy/__init__.py` using the existing comma style.

## Scope

- Files modified: `nemopy/_constructors.py`, `nemopy/__init__.py`, `tests/test_constructors.py` — matches TASK-12 target scope exactly.
- No dependencies added (pandas handled via `try/except ImportError`).

## Test plan

- [x] New tests cover every acceptance bullet, each with a stated goal per `CLAUDE.md` §6.1.
- [x] Branch is 0-behind `origin/main`; diff is +131/−4 across the three spec'd files only.
- [ ] Full `pytest` suite green (please verify on CI).

Reviewed against spec prior to PR open.