### PR TITLE
feat(operators): add in-place shape-guarded operators (TASK-06)

### DIFF
--- a/CopilotReview.md
+++ b/CopilotReview.md
@@ -1,0 +1,41 @@
+# Copilot Design Review (Open PRs #20–#29)
+
+## What was reviewed
+- Design source of truth: `/home/runner/work/nemopy/nemopy/.github/DESIGN.md` and `/home/runner/work/nemopy/nemopy/.github/DESIGN_APPENDICES.md`
+- Open PR set reviewed: #20, #21, #22, #23, #24, #25, #26, #27, #28, #29
+- Local integration simulation attempted by merging all 10 PR head branches onto `origin/main` in dependency order.
+
+## Conclusion
+As currently configured, the 10 open PRs do **not** provide a guaranteed path to a complete working program on `main` without additional integration work. The main issues are branch-targeting and merge-conflict hotspots, not missing feature intent.
+
+## Deviations / Omissions
+
+### 1) PR #29 is not targeted at `main`
+- **Design impact:** TASK-06 functionality (`__iadd__`, `__isub__`, `__imul__`, `__itruediv__`) is part of the required operator surface (DESIGN.md §7.7; Appendix B item 3).
+- **Problem location:** PR metadata for #29 (`base.ref = feat/arithmetic-shape-guards`, not `main`).
+- **Why problematic:** Even if all open PRs are merged “as-is,” #29 can merge into a feature branch without landing on `main`, leaving required in-place operators absent from the mainline.
+
+### 2) Core feature PRs collide in the same file regions
+- **Design impact:** Required Mat/ColVec capabilities from DESIGN.md §6.3, §9.1, §9.2, §9.3 and DESIGN_APPENDICES.md §13.2 must co-exist in one `Mat` class implementation.
+- **Problem locations:**
+  - `/home/runner/work/nemopy/nemopy/nemopy/_core.py` around `Mat` class tail (current file region ~lines 169+), where PRs #20/#21/#22/#24 each append properties/methods at the same anchor.
+  - `/home/runner/work/nemopy/nemopy/nemopy/_core.py` around `Mat.__getitem__` insertion point (PR #27).
+  - `/home/runner/work/nemopy/nemopy/tests/test_core.py` import block and large appended test sections (PRs #20/#21/#22/#23/#24/#27/#28/#29).
+- **Why problematic:** Local merge simulation produced conflicts in `_core.py` and `tests/test_core.py` before all branches could be integrated. Without manual conflict resolution, the combined implementation cannot be verified as working.
+
+### 3) `as_col` and `as_mat` PRs overlap and can drop one export
+- **Design impact:** DESIGN.md §2.3 requires both `as_col` and `as_mat` in `__all__`; DESIGN_APPENDICES.md §13.3 requires both inbound converters.
+- **Problem locations:**
+  - `/home/runner/work/nemopy/nemopy/nemopy/__init__.py` lines 3–13: PR #25 adds `as_col`; PR #26 adds `as_mat` in the same import/`__all__` block.
+  - `/home/runner/work/nemopy/nemopy/nemopy/_constructors.py` around end-of-file after `eye()` (current region ~line 118+): PR #25 adds `as_col`, PR #26 adds `as_mat` at the same insertion anchor.
+- **Why problematic:** These two PRs are independently correct but overlap structurally; unresolved integration can leave only one converter/export present, violating DESIGN.md §2.3.
+
+### 4) Full runtime verification is currently blocked in this environment
+- **Design impact:** “Working program” confirmation requires executing the test suite.
+- **Problem location:** Local environment command `python -m pytest tests/ -v` fails with `No module named pytest`.
+- **Why problematic:** Dynamic verification could not be completed in this sandbox without installing missing tooling.
+
+## Overall assessment
+- **Feature intent coverage across PRs:** strong.
+- **Integration readiness on `main`:** **not ready yet** due to branch targeting + merge-conflict hotspots.
+- **Required follow-up before claiming completion:** retarget/rebase + conflict resolution + full test run on the integrated branch.

--- a/CopilotReview.md
+++ b/CopilotReview.md
@@ -1,7 +1,7 @@
 # Copilot Design Review (Open PRs #20–#29)
 
 ## What was reviewed
-- Design source of truth: `/home/runner/work/nemopy/nemopy/.github/DESIGN.md` and `/home/runner/work/nemopy/nemopy/.github/DESIGN_APPENDICES.md`
+- Design source of truth: `.github/DESIGN.md` and `.github/DESIGN_APPENDICES.md`
 - Open PR set reviewed: #20, #21, #22, #23, #24, #25, #26, #27, #28, #29
 - Local integration simulation attempted by merging all 10 PR head branches onto `origin/main` in dependency order.
 
@@ -18,16 +18,16 @@ As currently configured, the 10 open PRs do **not** provide a guaranteed path to
 ### 2) Core feature PRs collide in the same file regions
 - **Design impact:** Required Mat/ColVec capabilities from DESIGN.md §6.3, §9.1, §9.2, §9.3 and DESIGN_APPENDICES.md §13.2 must co-exist in one `Mat` class implementation.
 - **Problem locations:**
-  - `/home/runner/work/nemopy/nemopy/nemopy/_core.py` around `Mat` class tail (current file region ~lines 169+), where PRs #20/#21/#22/#24 each append properties/methods at the same anchor.
-  - `/home/runner/work/nemopy/nemopy/nemopy/_core.py` around `Mat.__getitem__` insertion point (PR #27).
-  - `/home/runner/work/nemopy/nemopy/tests/test_core.py` import block and large appended test sections (PRs #20/#21/#22/#23/#24/#27/#28/#29).
+  - `nemopy/_core.py` around `Mat` class tail (current file region ~lines 169+), where PRs #20/#21/#22/#24 each append properties/methods at the same anchor.
+  - `nemopy/_core.py` around `Mat.__getitem__` insertion point (PR #27).
+  - `tests/test_core.py` import block and large appended test sections (PRs #20/#21/#22/#23/#24/#27/#28/#29).
 - **Why problematic:** Local merge simulation produced conflicts in `_core.py` and `tests/test_core.py` before all branches could be integrated. Without manual conflict resolution, the combined implementation cannot be verified as working.
 
 ### 3) `as_col` and `as_mat` PRs overlap and can drop one export
 - **Design impact:** DESIGN.md §2.3 requires both `as_col` and `as_mat` in `__all__`; DESIGN_APPENDICES.md §13.3 requires both inbound converters.
 - **Problem locations:**
-  - `/home/runner/work/nemopy/nemopy/nemopy/__init__.py` lines 3–13: PR #25 adds `as_col`; PR #26 adds `as_mat` in the same import/`__all__` block.
-  - `/home/runner/work/nemopy/nemopy/nemopy/_constructors.py` around end-of-file after `eye()` (current region ~line 118+): PR #25 adds `as_col`, PR #26 adds `as_mat` at the same insertion anchor.
+  - `nemopy/__init__.py` lines 3–13: PR #25 adds `as_col`; PR #26 adds `as_mat` in the same import/`__all__` block.
+  - `nemopy/_constructors.py` around end-of-file after `eye()` (current region ~line 118+): PR #25 adds `as_col`, PR #26 adds `as_mat` at the same insertion anchor.
 - **Why problematic:** These two PRs are independently correct but overlap structurally; unresolved integration can leave only one converter/export present, violating DESIGN.md §2.3.
 
 ### 4) Full runtime verification is currently blocked in this environment

--- a/nemopy/_operators.py
+++ b/nemopy/_operators.py
@@ -98,25 +98,25 @@ def __rmatmul__(self, other):
 
 
 def __iadd__(self, other):
-    _check_shapes(self, other, "+=")
+    _check_shapes(self, other, "+")
     super(_VecBase, self).__iadd__(other)
     return self
 
 
 def __isub__(self, other):
-    _check_shapes(self, other, "-=")
+    _check_shapes(self, other, "-")
     super(_VecBase, self).__isub__(other)
     return self
 
 
 def __imul__(self, other):
-    _check_shapes(self, other, "*=")
+    _check_shapes(self, other, "*")
     super(_VecBase, self).__imul__(other)
     return self
 
 
 def __itruediv__(self, other):
-    _check_shapes(self, other, "/=")
+    _check_shapes(self, other, "/")
     super(_VecBase, self).__itruediv__(other)
     return self
 

--- a/nemopy/_operators.py
+++ b/nemopy/_operators.py
@@ -95,6 +95,32 @@ def __rmatmul__(self, other):
                 stacklevel=2,
             )
     return super(_VecBase, self).__rmatmul__(other)
+
+
+def __iadd__(self, other):
+    _check_shapes(self, other, "+=")
+    super(_VecBase, self).__iadd__(other)
+    return self
+
+
+def __isub__(self, other):
+    _check_shapes(self, other, "-=")
+    super(_VecBase, self).__isub__(other)
+    return self
+
+
+def __imul__(self, other):
+    _check_shapes(self, other, "*=")
+    super(_VecBase, self).__imul__(other)
+    return self
+
+
+def __itruediv__(self, other):
+    _check_shapes(self, other, "/=")
+    super(_VecBase, self).__itruediv__(other)
+    return self
+
+
 _VecBase.__mul__ = __mul__
 _VecBase.__rmul__ = __rmul__
 _VecBase.__add__ = __add__
@@ -105,3 +131,7 @@ _VecBase.__truediv__ = __truediv__
 _VecBase.__rtruediv__ = __rtruediv__
 _VecBase.__matmul__ = __matmul__
 _VecBase.__rmatmul__ = __rmatmul__
+_VecBase.__iadd__ = __iadd__
+_VecBase.__isub__ = __isub__
+_VecBase.__imul__ = __imul__
+_VecBase.__itruediv__ = __itruediv__

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -213,6 +213,18 @@
           raise `ShapeError` for mismatched array shapes.
 - Expected: a subprocess that only runs `import nemopy; u + v` with
             shape-mismatched ColVecs raises `ShapeError`.
+
+## Test: test_import_nemopy_activates_inplace_shape_guards
+- Goal: Verify that `import nemopy` (alone) also activates the in-place
+        shape-guard monkey-patches, so `u += v` on shape-mismatched
+        `_VecBase` instances raises `ShapeError` without the test session
+        having imported `nemopy._operators` directly. Defends against a
+        future regression where in-place overrides drift into a module
+        that is not loaded by the package's `__init__`.
+- Source: DESIGN.md §7.7 — in-place operators call `_check_shapes` and
+          thus must be active on the same package-import path as §7.4.
+- Expected: a subprocess that runs `import nemopy; u += v` with
+            shape-mismatched ColVecs raises `ShapeError`.
 """
 
 import numpy as np
@@ -633,6 +645,47 @@ class TestShapeGuardsActivatedOnImport:
             v = nemopy.ColVec(np.ones((2, 1)))
             try:
                 u + v
+            except nemopy.ShapeError:
+                print("SHAPE_ERROR_RAISED")
+            except Exception as exc:
+                print("WRONG_ERROR:" + type(exc).__name__)
+            else:
+                print("NO_ERROR")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "SHAPE_ERROR_RAISED" in result.stdout, (
+            f"Expected ShapeError in subprocess, got stdout={result.stdout!r} "
+            f"stderr={result.stderr!r}"
+        )
+
+    def test_import_nemopy_activates_inplace_shape_guards(self):
+        """`import nemopy` alone must activate in-place shape-guard monkey-patches.
+
+        Sibling of `test_import_nemopy_activates_shape_guards` covering the
+        `u += v` path; uses a subprocess for the same reason — the test
+        session already imports `nemopy._operators` for its helpers, which
+        would mask a regression where in-place overrides are not wired up
+        via plain `import nemopy`.
+        """
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent(
+            """
+            import numpy as np
+            import nemopy
+
+            u = nemopy.ColVec(np.ones((3, 1)))
+            v = nemopy.ColVec(np.ones((2, 1)))
+            try:
+                u += v
             except nemopy.ShapeError:
                 print("SHAPE_ERROR_RAISED")
             except Exception as exc:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -178,6 +178,31 @@
           view" and "the subclass label of the left-hand operand is preserved".
 - Expected: for each of the 4 operators, `id(u)` is unchanged, `type(u)` is
             unchanged, and values equal the hand-computed reference.
+
+## Test: test_inplace_shape_error_uses_bare_op_symbol
+- Goal: Verify that `ShapeError` messages from in-place operators reference
+        the bare operator token (`+`, `-`, `*`, `/`) rather than the augmented
+        form (`+=`, etc.), so callers of `_check_shapes` receive identical
+        messages whether the call came from a binary or in-place operator.
+- Source: DESIGN.md §7.7 — in-place operators call `_check_shapes` identically.
+- Expected: the raised `ShapeError` message contains `'+'` / `'-'` / `'*'` /
+            `'/'` and does not contain `'+='` / `'-='` / `'*='` / `'/='`.
+
+## Test: test_inplace_mutates_in_place_and_preserves_label_mat
+- Goal: Verify §7.7's in-place contract (id unchanged, label preserved,
+        values correct) for `Mat` LHS, not only `ColVec` LHS.
+- Source: DESIGN.md §7.7 — in-place contract applies to all `_VecBase`
+          subclasses.
+- Expected: for each of the 4 operators, `id(A)` unchanged, `type(A)` is
+            `Mat`, values equal the hand-computed reference.
+
+## Test: test_inplace_scalar_rhs_passes
+- Goal: Verify that scalar RHS `+=`, `-=`, `*=`, `/=` do not raise and
+        produce the hand-computed result for both `ColVec` and `Mat` LHS.
+- Source: DESIGN.md §7.7 + §7.3 — scalar operations are always permitted
+          through `_check_shapes`.
+- Expected: for each operator and each LHS type, the in-place op succeeds
+            and the mutated array equals the hand-computed result.
 """
 
 import numpy as np
@@ -494,3 +519,81 @@ class TestInplaceOperators:
         assert isinstance(result, ColVec)
         assert result.shape == (3, 1)
         assert np.array_equal(np.asarray(result), expected)
+
+    @pytest.mark.parametrize(
+        "op, symbol",
+        [
+            (lambda a, b: a.__iadd__(b), "+"),
+            (lambda a, b: a.__isub__(b), "-"),
+            (lambda a, b: a.__imul__(b), "*"),
+            (lambda a, b: a.__itruediv__(b), "/"),
+        ],
+    )
+    def test_inplace_shape_error_uses_bare_op_symbol(self, op, symbol):
+        """In-place ShapeError messages reference the bare operator token."""
+        u = _c[1, 2, 3]
+        v = _c[4, 5]
+        with pytest.raises(ShapeError) as excinfo:
+            op(u, v)
+        msg = str(excinfo.value)
+        assert f"'{symbol}'" in msg
+        assert f"'{symbol}='" not in msg
+
+    @pytest.mark.parametrize(
+        "augmented, expected",
+        [
+            (lambda A, B: A.__iadd__(B), np.array([[8.0, 10.0], [12.0, 14.0]])),
+            (lambda A, B: A.__isub__(B), np.array([[-6.0, -6.0], [-6.0, -6.0]])),
+            (lambda A, B: A.__imul__(B), np.array([[7.0, 16.0], [27.0, 40.0]])),
+            (lambda A, B: A.__itruediv__(B), np.array([[1.0 / 7.0, 2.0 / 8.0], [3.0 / 9.0, 4.0 / 10.0]])),
+        ],
+    )
+    def test_inplace_mutates_in_place_and_preserves_label_mat(self, augmented, expected):
+        """In-place contract holds for Mat LHS (id unchanged, Mat label preserved, correct values)."""
+        A = Mat(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        B = Mat(np.array([[7.0, 8.0], [9.0, 10.0]]))
+        before = id(A)
+        result = augmented(A, B)
+        assert id(result) == before
+        assert isinstance(result, Mat)
+        assert not isinstance(result, ColVec)
+        assert result.shape == (2, 2)
+        assert np.allclose(np.asarray(result), expected)
+
+    @pytest.mark.parametrize(
+        "augmented, expected_colvec, expected_mat",
+        [
+            (
+                lambda x, s: x.__iadd__(s),
+                np.array([[3.0], [4.0], [5.0]]),
+                np.array([[3.0, 4.0], [5.0, 6.0]]),
+            ),
+            (
+                lambda x, s: x.__isub__(s),
+                np.array([[-1.0], [0.0], [1.0]]),
+                np.array([[-1.0, 0.0], [1.0, 2.0]]),
+            ),
+            (
+                lambda x, s: x.__imul__(s),
+                np.array([[2.0], [4.0], [6.0]]),
+                np.array([[2.0, 4.0], [6.0, 8.0]]),
+            ),
+            (
+                lambda x, s: x.__itruediv__(s),
+                np.array([[0.5], [1.0], [1.5]]),
+                np.array([[0.5, 1.0], [1.5, 2.0]]),
+            ),
+        ],
+    )
+    def test_inplace_scalar_rhs_passes(self, augmented, expected_colvec, expected_mat):
+        """Scalar RHS in-place ops do not raise and produce correct values for both ColVec and Mat."""
+        u = _c[1, 2, 3]
+        result_u = augmented(u, 2.0)
+        assert isinstance(result_u, ColVec)
+        assert np.allclose(np.asarray(result_u), expected_colvec)
+
+        A = Mat(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        result_A = augmented(A, 2.0)
+        assert isinstance(result_A, Mat)
+        assert not isinstance(result_A, ColVec)
+        assert np.allclose(np.asarray(result_A), expected_mat)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,6 +160,24 @@
         are `ColVec`/`Mat` subclasses.
 - Source: DESIGN.md §7.5 — warning applies only to plain ndarray operands.
 - Expected: no warnings for `ColVec @ Mat` and `Mat @ ColVec`.
+
+## Test: test_inplace_arithmetic_mismatched_shapes_raise_shape_error
+- Goal: Verify that `+=`, `-=`, `*=`, `/=` raise `ShapeError` when LHS and RHS
+        have different array shapes.
+- Source: DESIGN.md §7.7 — in-place operators call `_check_shapes`.
+- Expected: `ShapeError` is raised for a (3,1) LHS op= (2,1) RHS across all
+            four operators.
+
+## Test: test_inplace_mutates_in_place_and_preserves_label
+- Goal: Verify that `u += v` (and `-=`, `*=`, `/=`) mutate the existing array
+        view (`id` unchanged), preserve the subclass label, and produce the
+        hand-computed result — the three guarantees §7.7 adds beyond NumPy's
+        default augmented-assignment behaviour, which rebinds via
+        `__array_ufunc__` and thus changes the object identity.
+- Source: DESIGN.md §7.7 — "data is modified in-place on the existing array
+          view" and "the subclass label of the left-hand operand is preserved".
+- Expected: for each of the 4 operators, `id(u)` is unchanged, `type(u)` is
+            unchanged, and values equal the hand-computed reference.
 """
 
 import numpy as np
@@ -438,3 +456,41 @@ class TestMatmulConventionWarnings:
             _ = left_mat @ right_vec
 
         assert len(caught) == 0
+
+
+class TestInplaceOperators:
+    @pytest.mark.parametrize(
+        "op",
+        [
+            lambda a, b: a.__iadd__(b),
+            lambda a, b: a.__isub__(b),
+            lambda a, b: a.__imul__(b),
+            lambda a, b: a.__itruediv__(b),
+        ],
+    )
+    def test_inplace_arithmetic_mismatched_shapes_raise_shape_error(self, op):
+        """All four in-place operators raise ShapeError on mismatched array shapes."""
+        u = _c[1, 2, 3]
+        v = _c[4, 5]
+        with pytest.raises(ShapeError):
+            op(u, v)
+
+    @pytest.mark.parametrize(
+        "augmented, expected",
+        [
+            (lambda u, v: u.__iadd__(v), np.array([[5.0], [7.0], [9.0]])),
+            (lambda u, v: u.__isub__(v), np.array([[-3.0], [-3.0], [-3.0]])),
+            (lambda u, v: u.__imul__(v), np.array([[4.0], [10.0], [18.0]])),
+            (lambda u, v: u.__itruediv__(v), np.array([[0.25], [0.4], [0.5]])),
+        ],
+    )
+    def test_inplace_mutates_in_place_and_preserves_label(self, augmented, expected):
+        """`+=`, `-=`, `*=`, `/=` mutate the existing view (id unchanged), keep the ColVec label, and produce the hand-computed result."""
+        u = _c[1, 2, 3]
+        v = _c[4, 5, 6]
+        before = id(u)
+        result = augmented(u, v)
+        assert id(result) == before
+        assert isinstance(result, ColVec)
+        assert result.shape == (3, 1)
+        assert np.array_equal(np.asarray(result), expected)


### PR DESCRIPTION
## Summary

Implements **TASK-06** from `TASKS.md` — in-place operators `+=`, `-=`, `*=`, `/=` on `_VecBase` per `DESIGN.md` §7.7.

- `__iadd__`, `__isub__`, `__imul__`, `__itruediv__` each call `_check_shapes` (from TASK-04) before delegating to `super()`, then return `self` so Python's augmented-assignment preserves object identity.
- Two arrays of different shape raise `ShapeError`.
- Scalar right-hand sides pass through.
- Subclass label (`ColVec` or `Mat`) is preserved on the LHS.

## PR base

Targets `feat/arithmetic-shape-guards` rather than `main` because TASK-06 depends on the `_check_shapes` helper introduced by TASK-04 on that branch (per `TASKS.md` dependency map). Once PR #28 (TASK-04 + TASK-05) lands on `main`, this PR should be retargeted to `main` and rebased.

## Scope

- Files modified: `nemopy/_operators.py`, `tests/test_core.py` — exactly matches the TASK-06 target scope.
- No dependencies added. No unrelated reformatting.
- Diff vs `feat/arithmetic-shape-guards`: +86/−0.

## Test plan

- [x] Test-first: two parametrised test classes cover the shape guard (all 4 operators) and the in-place / label-preservation / value-correctness contract (all 4 operators). 8 variants total, all failing against the base branch and passing after the implementation lands (CLAUDE.md §6.2 red-green verified locally).
- [x] Each test has a stated goal in the module-docstring `## Test:` block per `CLAUDE.md` §6.1.
- [x] Full local `pytest` suite: 76 tests, all passing.
- [x] Cleanup audit (CLAUDE.md §9) applied: no debug litter, no unrelated changes, imports unchanged.

## Assumptions

- Returning `self` from the `__i*` methods is required because the inherited `np.ndarray.__iadd__` path routes through our `__array_ufunc__` override, which returns a freshly-wrapped view via `_apply_type_rules` — Python would otherwise rebind the LHS to that new object, breaking the in-place-identity contract in §7.7. Documented in the commit message but kept terse in the code per CLAUDE.md §8.3.