### PR TITLE
test(core): lock in ColVec.__getitem__ malformed-input guard

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -365,6 +365,8 @@ class TestColVecGetitem:
         to plain ndarray indexing rather than reshaping to (k, 1)."""
         u = ColVec(np.array([[1.0], [2.0], [3.0]]))
         flat = u.flatten()
+        assert isinstance(flat, ColVec)
+        assert flat.ndim == 1
         assert flat.shape == (3,)
         mask = np.array([True, False, True])
         result = flat[mask]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -132,6 +132,18 @@
         structure, returning a ColVec.
 - Source: DESIGN.md §6.1 table row 5 — "u[u > 25] → ColVec, shape (3, 1)".
 - Expected: u[u > 25] is a ColVec of shape (3, 1) with values [30, 40, 50].
+
+## Test: test_getitem_on_malformed_colvec_delegates_to_plain_ndarray
+- Goal: Verify that ColVec.__getitem__'s guard for malformed (non-(n, 1))
+        instances delegates to plain ndarray indexing instead of applying
+        the (k, 1) wrap. Without this guard, internal NumPy paths that
+        operate on the 1-D output of ColVec.flatten() (e.g.
+        np.testing.assert_array_compare) break.
+- Source: Implementation invariant from PR #19; protects against a
+          regression observed in
+          tests/test_constructors.py::TestColConstructor::test_c_basic.
+- Expected: flat[mask] where flat is a ColVec-labelled 1-D array returns a
+            plain np.ndarray of shape (k,), not a (k, 1) ColVec.
 """
 
 import numpy as np
@@ -347,3 +359,15 @@ class TestColVecGetitem:
         assert isinstance(result, ColVec)
         assert result.shape == (3, 1)
         assert np.array_equal(np.asarray(result), np.array([[30.0], [40.0], [50.0]]))
+
+    def test_getitem_on_malformed_colvec_delegates_to_plain_ndarray(self):
+        """Indexing a ColVec-labelled 1-D array (from .flatten()) delegates
+        to plain ndarray indexing rather than reshaping to (k, 1)."""
+        u = ColVec(np.array([[1.0], [2.0], [3.0]]))
+        flat = u.flatten()
+        assert flat.shape == (3,)
+        mask = np.array([True, False, True])
+        result = flat[mask]
+        assert type(result) is np.ndarray
+        assert result.shape == (2,)
+        np.testing.assert_array_equal(result, np.array([1.0, 3.0]))


### PR DESCRIPTION
## Summary

Closes #32.

Adds a regression test that pins the malformed-input guard in
`ColVec.__getitem__`:

```python
if self.ndim != 2 or self.shape[1] != 1:
    return np.asarray(self)[key]
```

The guard exists because `ColVec.flatten()` returns a ColVec-labelled
1-D array (the base class's `__array_finalize__` is a pass-through).
Without the guard, our override's 1-D branch reshapes that into `(k, 1)`,
which breaks `np.testing.assert_array_compare` — the root cause of the
`test_c_basic` failure observed during PR #19.

There is no production code change; the guard already ships in `main`.
Before this PR, removing the guard in a future refactor would leave
`TestColVecGetitem` green — the only test that caught it was an
unrelated integration test in `tests/test_constructors.py`. This test
directly exercises the guarded code path and fails when the guard is
removed.

## Test plan

- [x] `pytest` — full suite (45 tests) passes with the guard in place.
- [x] Manual red-green: removed the guard locally → new test fails with
      `AssertionError: assert <class 'ColVec'> is <class 'numpy.ndarray'>`.
      Restored → test passes.
- [x] Cleanup Audit (CLAUDE.md §9) and Scope Test (§2.3) applied to the
      diff.