### PR TITLE
refactor(core): remove duplicated operator overrides and Mat methods

### DIFF
--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -1,7 +1,5 @@
 """Core types: ColVec, Mat, _VecBase, ShapeError, ConventionWarning."""
 
-import warnings
-
 import numpy as np
 
 _NPY_MAJOR = int(np.__version__.split(".")[0])
@@ -40,28 +38,6 @@ def _apply_type_rules(result):
     if result.ndim == 2:
         return result.view(Mat)
     return np.asarray(result)
-
-
-def _is_scalar(x):
-    if isinstance(x, (int, float, complex, np.generic)):
-        return True
-    if isinstance(x, np.ndarray) and x.ndim == 0:
-        return True
-    return False
-
-
-def _check_shapes(a, b, op_name):
-    """Raise ShapeError if a and b are both arrays with different shapes."""
-    if _is_scalar(a) or _is_scalar(b):
-        return
-    a_shape = np.shape(a)
-    b_shape = np.shape(b)
-    if a_shape != b_shape:
-        raise ShapeError(
-            f"Element-wise '{op_name}' requires identical shapes, "
-            f"got {a_shape} and {b_shape}. "
-            f"If broadcasting is intended, use np.multiply / np.add directly."
-        )
 
 
 class _VecBase(np.ndarray):
@@ -145,84 +121,6 @@ class _VecBase(np.ndarray):
             Type determined by output shape (same rules as .T).
         """
         return self.conj().T
-
-    def __mul__(self, other):
-        _check_shapes(self, other, "*")
-        return super().__mul__(other)
-
-    def __rmul__(self, other):
-        _check_shapes(other, self, "*")
-        return super().__rmul__(other)
-
-    def __add__(self, other):
-        _check_shapes(self, other, "+")
-        return super().__add__(other)
-
-    def __radd__(self, other):
-        _check_shapes(other, self, "+")
-        return super().__radd__(other)
-
-    def __sub__(self, other):
-        _check_shapes(self, other, "-")
-        return super().__sub__(other)
-
-    def __rsub__(self, other):
-        _check_shapes(other, self, "-")
-        return super().__rsub__(other)
-
-    def __truediv__(self, other):
-        _check_shapes(self, other, "/")
-        return super().__truediv__(other)
-
-    def __rtruediv__(self, other):
-        _check_shapes(other, self, "/")
-        return super().__rtruediv__(other)
-
-    def __matmul__(self, other):
-        if isinstance(other, np.ndarray) and not isinstance(other, _VecBase):
-            if other.ndim == 2 and other.shape[0] < other.shape[1]:
-                warnings.warn(
-                    f"Right operand of @ is a plain ndarray with shape {other.shape} — "
-                    f"more columns than rows. If this came from np.array([[...]]), "
-                    f"it may be row-first and transposed relative to nemopy convention. "
-                    f"Wrap with Mat(...) to suppress this warning.",
-                    ConventionWarning,
-                    stacklevel=2,
-                )
-        return super().__matmul__(other)
-
-    def __rmatmul__(self, other):
-        if isinstance(other, np.ndarray) and not isinstance(other, _VecBase):
-            if other.ndim == 2 and other.shape[0] < other.shape[1]:
-                warnings.warn(
-                    f"Left operand of @ is a plain ndarray with shape {other.shape} — "
-                    f"more columns than rows. If this came from np.array([[...]]), "
-                    f"it may be row-first and transposed relative to nemopy convention. "
-                    f"Wrap with Mat(...) to suppress this warning.",
-                    ConventionWarning,
-                    stacklevel=2,
-                )
-        return super().__rmatmul__(other)
-
-    def __iadd__(self, other):
-        _check_shapes(self, other, "+")
-        super().__iadd__(other)
-        return self
-
-    def __isub__(self, other):
-        _check_shapes(self, other, "-")
-        super().__isub__(other)
-        return self
-
-    def __imul__(self, other):
-        _check_shapes(self, other, "*")
-        super().__imul__(other)
-        return self
-
-    def __itruediv__(self, other):
-        _check_shapes(self, other, "/")
-        super().__itruediv__(other)
-        return self
 
 
 class ColVec(_VecBase):
@@ -410,49 +308,6 @@ class Mat(_VecBase):
                 f"This matrix has shape {self.shape}."
             )
         return Mat(np.linalg.inv(self))
-
-    def to_numpy(self):
-        """Return a plain ndarray of shape (n, k). Strips subclass label.
-
-        Returns
-        -------
-        np.ndarray
-            Shape ``(n, k)``, dtype ``float64``.
-        """
-        return np.array(self)
-
-    def to_list(self):
-        """Return a nested list (list of rows, each a list of floats).
-
-        Returns
-        -------
-        list of list of float
-            Outer list has ``n`` elements, each inner list has ``k`` elements.
-        """
-        return self.tolist()
-
-    def to_dataframe(self, columns=None, index=None):
-        """Return a pandas DataFrame.
-
-        Parameters
-        ----------
-        columns : list of str, optional
-            Column labels. Defaults to integer range.
-        index : array-like, optional
-            Row index labels.
-
-        Returns
-        -------
-        pd.DataFrame
-
-        Raises
-        ------
-        ImportError
-            If pandas is not installed.
-        """
-        import pandas as pd
-
-        return pd.DataFrame(np.asarray(self), columns=columns, index=index)
 
     @property
     def is_singular(self):


### PR DESCRIPTION
## Summary

Removes two integration artefacts left on `main` after recent merges. No behaviour change; deletions only.

### 1. Duplicate operator overrides

`__mul__/__rmul__/__add__/__radd__/__sub__/__rsub__/__truediv__/__rtruediv__/__matmul__/__rmatmul__/__iadd__/__isub__/__imul__/__itruediv__` were defined twice — once in `_VecBase` class body in `nemopy/_core.py`, and again in `nemopy/_operators.py`, which monkey-patches them onto `_VecBase` at import time (DESIGN.md §2.2). The monkey-patch wins, so the class-body copies were dead code.

Also removed the duplicate `_is_scalar` and `_check_shapes` helpers from `_core.py` (canonical copies live in `_operators.py`), plus the `warnings` import in `_core.py` that those overrides were the only consumer of.

### 2. Duplicate `Mat` outbound conversion methods

`Mat.to_numpy` / `Mat.to_list` / `Mat.to_dataframe` were defined twice inside `Mat`. Python silently kept only the second set (which uses `dtype=np.float64` explicitly, matching DESIGN_APPENDICES.md §13.2); the first set (from PR #24's tail) was dead code. Removed the dead set.

## Spec mapping

- DESIGN.md §2.2 — operator overrides live in `_operators.py`
- DESIGN_APPENDICES.md §13.2 — `Mat.to_numpy` returns float64

## Test plan

- [ ] `python -m pip install --editable .` (after the packaging PR lands)
- [ ] `pytest tests/test_core.py -v` — operator and outbound-conversion tests pass unchanged
- [ ] `grep -c "def __mul__" nemopy/_core.py` → 0 (was 1)
- [ ] `grep -c "def __mul__" nemopy/_operators.py` → 1 (unchanged)
- [ ] `grep -c "def to_numpy" nemopy/_core.py` → 2 (one ColVec, one Mat — was 3)

## Out of scope

- Restoring `as_col` / `as_mat` (separate PR — currently broken on `main`)
- Packaging / CI / docs hosting (tracked in #40 / #41 / #42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjVb8XGtg2KRFiZ8FREqXA)_