### PR TITLE
fix(constructors): restore as_col and as_mat, fix __all__, fix test import

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,10 @@ Constructors
 
 .. autofunction:: nemopy.eye
 
+.. autofunction:: nemopy.as_col
+
+.. autofunction:: nemopy.as_mat
+
 Types
 -----
 

--- a/nemopy/__init__.py
+++ b/nemopy/__init__.py
@@ -1,13 +1,15 @@
 """nemopy — A column-vector-first NumPy wrapper."""
 
 from nemopy._core import ColVec, Mat, ShapeError, ConventionWarning  # noqa: F401
-from nemopy._constructors import _c, mat, eye, as_col  # noqa: F401
+from nemopy._constructors import _c, mat, eye, as_col, as_mat  # noqa: F401
 from nemopy import _operators  # noqa: F401  # side-effect: installs shape-guard operator overrides
 
 __all__ = [
     "_c",
     "mat",
     "eye",
+    "as_col",
+    "as_mat",
     "ColVec",
     "Mat",
     "ShapeError",

--- a/nemopy/_constructors.py
+++ b/nemopy/_constructors.py
@@ -1,4 +1,4 @@
-"""Constructors: _c singleton, mat(), eye(), as_col()."""
+"""Constructors: _c singleton, mat(), eye(), as_col(), as_mat()."""
 
 import warnings
 
@@ -118,3 +118,133 @@ def eye(n):
         Shape ``(n, n)`` identity matrix with dtype ``float64``.
     """
     return Mat(np.eye(int(n)))
+
+
+def as_col(x):
+    """Convert any array-like to a ColVec.
+
+    Accepts 1D arrays, flat lists, pandas Series, (n,1) arrays, and
+    scalar values. Performs reshaping as needed.
+
+    Parameters
+    ----------
+    x : array-like
+        Input data. Must be convertible to a 1D or (n,1) numeric array.
+
+    Returns
+    -------
+    ColVec
+        Shape ``(n, 1)``.
+
+    Raises
+    ------
+    ShapeError
+        If ``x`` is 2D with more than one column (ambiguous — which column?).
+    TypeError
+        If ``x`` cannot be converted to a numeric array.
+
+    Examples
+    --------
+    >>> as_col([1, 2, 3])
+    ColVec([1.0, 2.0, 3.0])
+
+    >>> as_col(42)
+    ColVec([42.0])
+
+    See Also
+    --------
+    _c : Bracket-notation constructor for column vectors from literals.
+    ColVec : Direct constructor (requires shape (n,1) exactly).
+    """
+    if isinstance(x, (int, float, complex, np.generic)):
+        return ColVec(np.array([[float(x)]]))
+
+    try:
+        import pandas as pd
+
+        if isinstance(x, pd.Series):
+            return ColVec(x.values.astype(float).reshape(-1, 1))
+    except ImportError:
+        pass
+
+    try:
+        arr = np.asarray(x, dtype=float)
+    except (ValueError, TypeError) as exc:
+        raise TypeError(
+            f"as_col() could not convert input to a numeric array: {exc}"
+        ) from exc
+
+    if arr.ndim == 0:
+        return ColVec(arr.reshape(1, 1))
+    if arr.ndim == 1:
+        return ColVec(arr.reshape(-1, 1))
+    if arr.ndim == 2 and arr.shape[1] == 1:
+        return ColVec(arr)
+    if arr.ndim == 2:
+        raise ShapeError(
+            f"as_col() received a 2D array with shape {arr.shape}. "
+            f"Cannot determine which column to extract. "
+            f"Pass a single column: as_col(arr[:, j])"
+        )
+    raise ShapeError(
+        f"as_col() requires a 1D or (n,1) input, got ndim={arr.ndim}."
+    )
+
+
+def as_mat(x):
+    """Convert any 2D array-like to a Mat.
+
+    Accepts 2D arrays, nested lists, pandas DataFrames, and existing
+    Mat instances.
+
+    Parameters
+    ----------
+    x : array-like
+        Input data. Must be convertible to a 2D numeric array.
+
+    Returns
+    -------
+    Mat
+        Shape ``(n, k)``.
+
+    Raises
+    ------
+    ShapeError
+        If ``x`` is not 2D after conversion.
+    TypeError
+        If ``x`` cannot be converted to a numeric array.
+
+    Examples
+    --------
+    >>> as_mat([[1, 2], [3, 4], [5, 6]])
+    Mat(3x2):
+      [1, 2]
+      [3, 4]
+      [5, 6]
+
+    See Also
+    --------
+    mat : Column-first matrix constructor.
+    Mat : Direct constructor (requires 2D input).
+    """
+    try:
+        import pandas as pd
+
+        if isinstance(x, pd.DataFrame):
+            return Mat(x.values.astype(float))
+    except ImportError:
+        pass
+
+    try:
+        arr = np.asarray(x, dtype=float)
+    except (ValueError, TypeError) as exc:
+        raise TypeError(
+            f"as_mat() could not convert input to a numeric array: {exc}"
+        ) from exc
+
+    if arr.ndim != 2:
+        raise ShapeError(
+            f"as_mat() requires a 2D input, got ndim={arr.ndim} "
+            f"with shape {arr.shape}."
+        )
+    return Mat(arr)

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -126,7 +126,7 @@
 import numpy as np
 import pytest
 
-from nemopy import _c, as_col, mat, eye, as_mat, ColVec, Mat, ShapeError, ShapeError
+from nemopy import _c, as_col, mat, eye, as_mat, ColVec, Mat, ShapeError
 
 
 class TestColConstructor:


### PR DESCRIPTION
Superseded by commits already merged into `main` (commit `b30e4a6` "fix(api): restore converter exports and align indexing contracts" plus follow-up tightening). The current `main` already has functional `as_col` / `as_mat`, the `__all__` correction, the test import fix, and the api.rst directives. This branch's implementation is incompatible (e.g. main has explicit complex-scalar handling; this branch's simpler `float(x)` would regress that behaviour).

Closing as no-op. The audit work continues on PR #44 and the new `feat/deploy-ready` branch.