### PR TITLE
feat: pip-installable packaging + MATLAB-style _m constructor

### DIFF
--- a/.github/DESIGN.md
+++ b/.github/DESIGN.md
@@ -158,7 +158,7 @@ nemopy
 nemopy/
 ├── __init__.py          # re-exports public API
 ├── _core.py             # ColVec, Mat, _VecBase, ShapeError, ConventionWarning
-├── _constructors.py     # _c singleton, mat(), eye()
+├── _constructors.py     # _c singleton, _m singleton, mat(), eye(), as_col(), as_mat()
 └── _operators.py        # operator override logic (mixed into _VecBase)
 ```
 
@@ -171,6 +171,7 @@ that the public API is importable from `nemopy` directly.
 ```python
 __all__ = [
     "_c",
+    "_m",
     "mat",
     "eye",
     "as_col",

--- a/.github/DESIGN_APPENDICES.md
+++ b/.github/DESIGN_APPENDICES.md
@@ -664,6 +664,83 @@ rank-2 objects, it is out of scope.
 
 ---
 
+## 17. MATLAB-style String Constructor `_m`
+
+### 17.1 Rationale
+
+Python does not allow `[1, 2, 3; 4, 5, 6]` as a literal — semicolons are
+not valid inside list brackets. Users coming from MATLAB / Octave / Julia
+frequently want a one-line literal for a matrix. `_m` provides the closest
+viable Python syntax: a singleton with `__getitem__` that takes a single
+string and parses it.
+
+`_m` is column-first by default to match nemopy's overall convention
+(§3, §5). The `.T` property on the resulting `Mat` yields the row-first
+MATLAB interpretation for users who want it.
+
+### 17.2 Surface
+
+```python
+_m: _MatConstructor    # singleton in nemopy._constructors
+
+# Forms that all parse identically
+A = _m["1, 2, 3; 4, 5, 6; 7, 8, 9"]
+B = _m["[1, 2, 3; 4, 5, 6; 7, 8, 9]"]   # MATLAB-true brackets tolerated
+C = _m["1 2 3; 4 5 6; 7 8 9"]            # whitespace separators
+```
+
+All three of `A`, `B`, `C` are `Mat(3, 3)` whose **columns** are
+`[1, 2, 3]`, `[4, 5, 6]`, `[7, 8, 9]`.
+
+### 17.3 Grammar
+
+```
+expr        := optional-brackets columns optional-brackets
+columns     := column ( ';' column )*
+column      := element ( separator element )*
+separator   := ',' | whitespace+
+element     := signed numeric token convertible to float
+optional-brackets := '[' ... ']'   (only at the very start and end)
+```
+
+### 17.4 Behaviour and errors
+
+| Input                          | Result                             |
+|--------------------------------|------------------------------------|
+| `_m["1, 2; 3, 4"]`             | `Mat(2, 2)` cols `[1,2]`, `[3,4]`  |
+| `_m["1 2; 3 4"]`               | same as above (whitespace = comma) |
+| `_m["[1, 2; 3, 4]"]`           | same as above (brackets stripped)  |
+| `_m["1, 2, 3"]`                | `Mat(3, 1)` (single column)        |
+| `_m["1, 2; 3, 4, 5"]`          | raises `ValueError` (ragged)       |
+| `_m["1, a; 3, 4"]`             | raises `TypeError` (non-numeric)   |
+| `_m[""]`, `_m["[]"]`           | raises `ValueError` (empty)        |
+| `_m["1, 2; ; 3, 4"]`           | raises `ValueError` (empty col)    |
+| `_m[1, 2, 3]` (not a string)   | raises `TypeError`                 |
+
+### 17.5 Row-first interpretation via `.T`
+
+For users who want the MATLAB-true row-first reading, transpose the result:
+
+```python
+# columns [1, 2, 3] and [4, 5, 6]  — nemopy column-first default
+A = _m["1, 2, 3; 4, 5, 6"]            # Mat(3, 2)
+
+# rows [1, 2, 3] and [4, 5, 6]  — MATLAB-true row-first
+A_rows = _m["1, 2, 3; 4, 5, 6"].T     # Mat(2, 3)
+```
+
+### 17.6 dtype
+
+Always `float64`, matching `_c[]` and `mat()`. Tokens are parsed via
+`float(...)`, so any literal Python `float`-convertible string is accepted
+(`"1e-3"`, `"-2.5"`, `"+0"`, `"inf"`, `"nan"`).
+
+### 17.7 `__all__` registration
+
+`_m` is added to `__all__` in `nemopy/__init__.py` alongside `_c`.
+
+---
+
 ## Appendix A. Documentation Specification
 
 *This appendix specifies the documentation tooling and format. It is an implementation

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# nemopy
+
+A column-vector-first NumPy wrapper. Vectors are `(n, 1)` by default;
+matrices are constructed column-by-column; arithmetic raises a clear
+`ShapeError` when shapes disagree instead of silently broadcasting.
+
+## Install
+
+```bash
+pip install nemopy                  # core (numpy only)
+pip install "nemopy[pandas]"        # adds pandas Series / DataFrame interop
+pip install "nemopy[dev]"           # adds pytest + sphinx for development
+```
+
+## Quick start
+
+```python
+import nemopy as nm
+
+u = nm._c[1, 2, 3]                  # ColVec, shape (3, 1)
+v = nm._c[4, 5, 6]                  # ColVec, shape (3, 1)
+
+A = nm.mat(u, v)                    # Mat, shape (3, 2), columns are u and v
+I = nm.eye(3)                       # 3x3 identity Mat
+
+# MATLAB-style string syntax — columns separated by ';', elements by ',' or whitespace
+B = nm._m["1, 2, 3; 4, 5, 6; 7, 8, 9"]   # Mat (3,3), columns [1,2,3] [4,5,6] [7,8,9]
+B_rows = nm._m["1, 2, 3; 4, 5, 6; 7, 8, 9"].T   # rows [1,2,3] [4,5,6] [7,8,9]
+
+# Inbound converters
+c = nm.as_col([10, 20, 30])         # ColVec from list / Series / 1D array
+M = nm.as_mat([[1, 2], [3, 4]])     # Mat from row-first nested list / DataFrame
+
+# Outbound converters
+u.to_list()                         # [1.0, 2.0, 3.0]
+A.to_numpy()                        # plain ndarray, shape (3, 2)
+
+# Matrix properties
+A_sq = nm.mat(nm._c[1, 2], nm._c[3, 4])
+A_sq.det                            # determinant
+A_sq.inv                            # inverse Mat
+A_sq.is_singular                    # bool
+```
+
+## Why column-first?
+
+Linear algebra is column-first: a matrix-vector product `A @ x` reads
+naturally when `x` is a column. nemopy enforces that convention end-to-end
+so column extraction (`A[:, j]`) returns a `ColVec` you can plug straight
+into `@` without reshaping.
+
+## Documentation
+
+The full behavioural specification lives in
+[`.github/DESIGN.md`](.github/DESIGN.md) and
+[`.github/DESIGN_APPENDICES.md`](.github/DESIGN_APPENDICES.md). Sphinx-built
+API docs are configured in `docs/`.
+
+## License
+
+BSD 3-Clause. See [LICENSE](LICENSE).

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,6 +7,9 @@ Constructors
 .. autodata:: nemopy._c
    :no-value:
 
+.. autodata:: nemopy._m
+   :no-value:
+
 .. autofunction:: nemopy.mat
 
 .. autofunction:: nemopy.eye

--- a/nemopy/__init__.py
+++ b/nemopy/__init__.py
@@ -1,11 +1,14 @@
 """nemopy — A column-vector-first NumPy wrapper."""
 
+__version__ = "0.1.0"
+
 from nemopy._core import ColVec, Mat, ShapeError, ConventionWarning  # noqa: F401
-from nemopy._constructors import _c, mat, eye, as_col, as_mat  # noqa: F401
+from nemopy._constructors import _c, _m, mat, eye, as_col, as_mat  # noqa: F401
 from nemopy import _operators  # noqa: F401  # side-effect: installs shape-guard operator overrides
 
 __all__ = [
     "_c",
+    "_m",
     "mat",
     "eye",
     "as_col",

--- a/nemopy/_constructors.py
+++ b/nemopy/_constructors.py
@@ -1,4 +1,4 @@
-"""Constructors: _c singleton, mat(), eye(), as_col(), as_mat()."""
+"""Constructors: _c singleton, _m singleton, mat(), eye(), as_col(), as_mat()."""
 
 import warnings
 
@@ -29,6 +29,71 @@ class _ColConstructor:
 
 
 _c = _ColConstructor()
+
+
+class _MatConstructor:
+    """Singleton bracket-notation matrix constructor with MATLAB-style syntax.
+
+    Usage
+    -----
+    >>> _m["1, 2, 3; 4, 5, 6; 7, 8, 9"]                # noqa
+    Mat with shape (3, 3) whose columns are [1,2,3], [4,5,6], [7,8,9].
+
+    The string is parsed column-by-column: rows of the literal (separated
+    by ``;``) become columns of the resulting matrix, matching nemopy's
+    column-first convention. To get the row-first MATLAB interpretation,
+    transpose with ``.T``::
+
+        _m["1, 2, 3; 4, 5, 6"].T  # rows [1,2,3] and [4,5,6]
+
+    Element separators inside a column may be commas, whitespace, or both.
+    Optional surrounding ``[...]`` brackets are tolerated to mirror the
+    MATLAB literal exactly.
+    """
+
+    def __getitem__(self, item):
+        if not isinstance(item, str):
+            raise TypeError(
+                "_m[] takes a single string. "
+                'Example: _m["1, 2, 3; 4, 5, 6; 7, 8, 9"]'
+            )
+        text = item.strip()
+        if text.startswith("[") and text.endswith("]"):
+            text = text[1:-1].strip()
+        if not text:
+            raise ValueError("_m[] received an empty string.")
+
+        col_strs = [s.strip() for s in text.split(";")]
+        cols = []
+        for i, col_str in enumerate(col_strs):
+            if not col_str:
+                raise ValueError(
+                    f"_m[] column {i} is empty. "
+                    f"Use a single ';' between columns, no trailing or leading ';'."
+                )
+            tokens = [t for t in col_str.replace(",", " ").split() if t]
+            try:
+                values = [float(t) for t in tokens]
+            except ValueError as exc:
+                raise TypeError(
+                    f"_m[] column {i} contains a non-numeric token: {exc}"
+                ) from exc
+            cols.append(values)
+
+        lengths = {len(c) for c in cols}
+        if len(lengths) > 1:
+            raise ValueError(
+                f"_m[] columns have unequal lengths: {[len(c) for c in cols]}. "
+                f"All columns must have the same number of rows."
+            )
+
+        return Mat(np.array(cols, dtype=float).T)
+
+    def __repr__(self):
+        return "_m"
+
+
+_m = _MatConstructor()
 
 
 def _to_colvec(arg, index):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nemopy"
+version = "0.1.0"
+description = "A column-vector-first NumPy wrapper with MATLAB-style matrix syntax."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "BSD-3-Clause" }
+authors = [{ name = "Naeem Paruk" }]
+keywords = ["numpy", "linear-algebra", "column-vectors", "matlab"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Mathematics",
+]
+dependencies = [
+    "numpy>=1.20",
+]
+
+[project.optional-dependencies]
+pandas = ["pandas>=1.0"]
+docs = [
+    "sphinx>=4.0",
+    "sphinx-rtd-theme>=1.0",
+]
+dev = [
+    "pytest>=7.0",
+    "pandas>=1.0",
+    "sphinx>=4.0",
+    "sphinx-rtd-theme>=1.0",
+]
+
+[project.urls]
+Repository = "https://github.com/n3m0-wits/nemopy"
+Issues = "https://github.com/n3m0-wits/nemopy/issues"
+
+[tool.setuptools.packages.find]
+include = ["nemopy*"]
+exclude = ["tests*", "docs*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -126,7 +126,7 @@
 import numpy as np
 import pytest
 
-from nemopy import _c, as_col, as_mat, eye, mat, ColVec, Mat, ShapeError
+from nemopy import _c, _m, as_col, as_mat, eye, mat, ColVec, Mat, ShapeError
 
 
 class TestColConstructor:
@@ -268,3 +268,85 @@ class TestAsMatConstructor:
         """as_mat([['a', 'b'], ['c', 'd']]) raises TypeError per the contract."""
         with pytest.raises(TypeError):
             as_mat([["a", "b"], ["c", "d"]])
+
+
+## Test: test_m_columns_default
+# - Goal: Verify _m["1, 2, 3; 4, 5, 6; 7, 8, 9"] returns Mat (3,3) whose columns
+#         are [1,2,3], [4,5,6], [7,8,9] per nemopy column-first convention.
+# - Source: DESIGN_APPENDICES.md §17 (MATLAB-style _m string constructor).
+# - Expected: shape (3, 3), column 0 == [1,2,3], column 2 == [7,8,9].
+#
+## Test: test_m_transpose_to_rows
+# - Goal: Verify the .T modifier flips the column-first interpretation to rows,
+#         giving the row-first MATLAB result.
+# - Source: DESIGN_APPENDICES.md §17.
+#
+## Test: test_m_unequal_columns_raises
+# - Goal: Verify unequal column lengths raise ValueError.
+#
+## Test: test_m_non_numeric_raises
+# - Goal: Verify non-numeric tokens raise TypeError.
+#
+## Test: test_m_brackets_tolerated
+# - Goal: Verify "[1, 2; 3, 4]" with surrounding [] parses identically.
+#
+## Test: test_m_whitespace_separator
+# - Goal: Verify whitespace works as element separator (MATLAB-true).
+#
+## Test: test_m_empty_string_raises
+# - Goal: Verify "" or "[]" raises ValueError.
+#
+## Test: test_m_non_string_input_raises
+# - Goal: Verify non-string subscripts raise TypeError.
+class TestMatlabConstructor:
+    def test_m_columns_default(self):
+        """_m['1, 2, 3; 4, 5, 6; 7, 8, 9'] has columns [1,2,3], [4,5,6], [7,8,9]."""
+        A = _m["1, 2, 3; 4, 5, 6; 7, 8, 9"]
+        assert isinstance(A, Mat)
+        assert A.shape == (3, 3)
+        np.testing.assert_array_equal(A[:, 0].flatten(), [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(A[:, 1].flatten(), [4.0, 5.0, 6.0])
+        np.testing.assert_array_equal(A[:, 2].flatten(), [7.0, 8.0, 9.0])
+
+    def test_m_transpose_to_rows(self):
+        """_m['1, 2, 3; 4, 5, 6; 7, 8, 9'].T has rows [1,2,3], [4,5,6], [7,8,9]."""
+        A = _m["1, 2, 3; 4, 5, 6; 7, 8, 9"].T
+        assert A.shape == (3, 3)
+        np.testing.assert_array_equal(np.asarray(A[0, :]).flatten(), [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(np.asarray(A[1, :]).flatten(), [4.0, 5.0, 6.0])
+        np.testing.assert_array_equal(np.asarray(A[2, :]).flatten(), [7.0, 8.0, 9.0])
+
+    def test_m_unequal_columns_raises(self):
+        """_m['1, 2; 3, 4, 5'] raises ValueError for ragged columns."""
+        with pytest.raises(ValueError):
+            _m["1, 2; 3, 4, 5"]
+
+    def test_m_non_numeric_raises(self):
+        """_m['1, a; 3, 4'] raises TypeError for non-numeric tokens."""
+        with pytest.raises(TypeError):
+            _m["1, a; 3, 4"]
+
+    def test_m_brackets_tolerated(self):
+        """_m['[1, 2; 3, 4]'] equals _m['1, 2; 3, 4']."""
+        A = _m["[1, 2; 3, 4]"]
+        B = _m["1, 2; 3, 4"]
+        np.testing.assert_array_equal(np.asarray(A), np.asarray(B))
+
+    def test_m_whitespace_separator(self):
+        """_m['1 2 3; 4 5 6'] parses with whitespace separators."""
+        A = _m["1 2 3; 4 5 6"]
+        assert A.shape == (3, 2)
+        np.testing.assert_array_equal(A[:, 0].flatten(), [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(A[:, 1].flatten(), [4.0, 5.0, 6.0])
+
+    def test_m_empty_string_raises(self):
+        """_m[''] and _m['[]'] raise ValueError."""
+        with pytest.raises(ValueError):
+            _m[""]
+        with pytest.raises(ValueError):
+            _m["[]"]
+
+    def test_m_non_string_input_raises(self):
+        """_m[1, 2, 3] (non-string) raises TypeError."""
+        with pytest.raises(TypeError):
+            _m[1, 2, 3]


### PR DESCRIPTION
## Summary

Two bundled changes that together get nemopy to "deployable as a Python import":

### 1. Packaging (addresses #40)

- `pyproject.toml` (PEP 621): `name=nemopy`, `version=0.1.0`, `requires-python>=3.9`, `numpy>=1.20` dep, optional extras `[pandas]` / `[docs]` / `[dev]`. setuptools build backend. License `BSD-3-Clause` matching the existing `LICENSE` file.
- `README.md` at repo root: install instructions + quick-start (covering `_c`, `_m`, `mat`, `eye`, `as_col`/`as_mat`, conversions, `det`/`inv`/`is_singular`).
- `__version__ = "0.1.0"` on `nemopy/__init__.py`.

After this, `pip install .` from a clean venv works and `python -c "import nemopy; print(nemopy.__version__)"` prints `0.1.0`.

### Decisions made for #40 (see commit body for full rationale)

| Question | Decision |
|----------|----------|
| Python floor | 3.9 |
| NumPy floor | 1.20 (matches DESIGN.md §4.5) |
| Pandas | optional extra `[pandas]` (matches lazy-import pattern already in code) |
| Build backend | setuptools |
| Version scheme | static `0.1.0` |
| `py.typed` marker | not added (no type hints in code yet) |
| License SPDX | `BSD-3-Clause` |

### 2. MATLAB-style `_m["..."]` matrix constructor

Adds a new singleton mirroring `_c[...]` for full matrices:

```python
_m["1, 2, 3; 4, 5, 6; 7, 8, 9"]   # Mat(3,3), columns [1,2,3] [4,5,6] [7,8,9]
_m["1, 2, 3; 4, 5, 6; 7, 8, 9"].T # rows [1,2,3] [4,5,6] [7,8,9]
```

Column-first by default to match nemopy's convention; `.T` gives the row-first MATLAB-true semantics. Element separators may be commas, whitespace, or both. Optional `[...]` surrounding brackets are tolerated to mirror MATLAB literals exactly.

**Errors**:

| Input | Result |
|-------|--------|
| `_m["1, 2; 3, 4, 5"]` | `ValueError` (ragged) |
| `_m["1, a; 3, 4"]` | `TypeError` (non-numeric) |
| `_m[""]`, `_m["[]"]` | `ValueError` (empty) |
| `_m[1, 2, 3]` (non-string) | `TypeError` |

Eight tests added in `TestMatlabConstructor` covering: column-first default, `.T` row-first, ragged columns, non-numeric, brackets, whitespace separator, empty, non-string.

### Spec amendment

- `DESIGN.md` §2.2 (package layout comment) and §2.3 (`__all__`) updated to include `_m`.
- New §17 added to `DESIGN_APPENDICES.md`: rationale, surface, grammar, behaviour table, dtype, `__all__` registration.

This is an authorised deviation from `CLAUDE.md` §10 (#5 — adding public functions outside `DESIGN.md`) per §11 — the user explicitly requested MATLAB-style syntax which the original spec did not anticipate.

## Why bundled

Packaging + the new feature share `__init__.py` and `_constructors.py`, and both depend on the audit conclusions in `/root/.claude/plans/the-outstanding-prs-have-curried-castle.md`. Splitting them into separate PRs would force a stack with rebase churn for marginal review benefit. Two distinct commits on a single branch trade off neatly.

## Test plan

- [ ] `pip install .` in a clean venv (and `pip install ".[dev]"`)
- [ ] `python -c "import nemopy; print(nemopy.__version__, nemopy.__all__)"`
- [ ] `python -c "import nemopy as nm; print(nm._m['1,2,3; 4,5,6; 7,8,9'])"`
- [ ] `pytest tests/test_constructors.py::TestMatlabConstructor -v`
- [ ] `pytest tests/ -v`

## Outstanding (not in this PR)

- PR #44 — dedup operator overrides + duplicate `Mat` methods in `_core.py`
- #41 — CI workflows
- #42 — Sphinx docs build / Read the Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjVb8XGtg2KRFiZ8FREqXA)_