### PR TITLE
Implement __array_function__ (NEP 18) for type persistence

### DIFF
--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -78,6 +78,25 @@ def _apply_type_rules(result):
     return np.asarray(result)
 
 
+HANDLED_FUNCTIONS = {}
+
+
+def implements(np_function):
+    """Register an __array_function__ override."""
+    def decorator(func):
+        HANDLED_FUNCTIONS[np_function] = func
+        return func
+    return decorator
+
+
+def _strip_vecbase(arg):
+    if isinstance(arg, _VecBase):
+        return np.asarray(arg)
+    if isinstance(arg, (list, tuple)):
+        return type(arg)(_strip_vecbase(a) for a in arg)
+    return arg
+
+
 class _VecBase(np.ndarray):
     """Non-public base class for ColVec and Mat.
 
@@ -116,6 +135,25 @@ class _VecBase(np.ndarray):
                 return tuple(_apply_type_rules(r) for r in results)
 
             return _apply_type_rules(results)
+
+    def __array_function__(self, func, types, args, kwargs):
+        if not all(issubclass(t, _VecBase) for t in types):
+            return NotImplemented
+        if func in HANDLED_FUNCTIONS:
+            return HANDLED_FUNCTIONS[func](*args, **kwargs)
+        args_as_np = tuple(_strip_vecbase(a) for a in args)
+        kwargs_as_np = {
+            k: _strip_vecbase(v) for k, v in kwargs.items()
+        }
+        result = func(*args_as_np, **kwargs_as_np)
+        if isinstance(result, np.ndarray):
+            return _apply_type_rules(result)
+        if isinstance(result, tuple):
+            return tuple(
+                _apply_type_rules(r) if isinstance(r, np.ndarray) else r
+                for r in result
+            )
+        return result
 
     @property
     def T(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -240,6 +240,7 @@ import warnings
 from unittest import mock
 
 from nemopy import _c, ColVec, ConventionWarning, Mat, ShapeError, mat
+from nemopy._core import _VecBase
 from nemopy._constructors import _c
 from nemopy._operators import _is_scalar, _check_shapes
 
@@ -742,3 +743,103 @@ class TestMatOutboundConversions:
         A = Mat(np.array([[1, 2], [3, 4]], dtype=float))
         with pytest.raises(ImportError):
             A.to_dataframe()
+
+
+## Test: test_array_function_linalg_solve
+# - Goal: Verify that np.linalg.solve(Mat, ColVec) returns a ColVec with
+#         correct values, not a plain ndarray.
+# - Source: Issue #50 — __array_function__ preserves type through np.linalg.
+# - Expected: isinstance(result, ColVec), shape (2,1), values match solution.
+
+## Test: test_array_function_linalg_eig
+# - Goal: Verify that np.linalg.eig(Mat) returns a tuple where eigenvalues
+#         are plain ndarray (1D) and eigenvectors are Mat (2D).
+# - Source: Issue #50 — tuple results apply type rules per element.
+# - Expected: eigenvalues not _VecBase, eigenvectors isinstance Mat.
+
+## Test: test_array_function_sort
+# - Goal: Verify that np.sort(ColVec, axis=0) returns ColVec with sorted values.
+# - Source: Issue #50 — non-ufunc functions preserve type via __array_function__.
+# - Expected: isinstance(result, ColVec), values sorted ascending.
+
+## Test: test_array_function_concatenate
+# - Goal: Verify that np.concatenate([ColVec, ColVec], axis=0) returns ColVec.
+# - Source: Issue #50 — arrays nested in list args are handled correctly.
+# - Expected: isinstance(result, ColVec), shape (4,1).
+
+## Test: test_array_function_reshape
+# - Goal: Verify that np.reshape(ColVec(3,1), (1,-1)) returns Mat(1,3).
+# - Source: Issue #50 — shape (1,3) maps to Mat per _apply_type_rules.
+# - Expected: isinstance(result, Mat), shape (1,3).
+
+## Test: test_array_function_scalar_result
+# - Goal: Verify that np.sum(ColVec) returns a plain scalar, not wrapped.
+# - Source: Issue #50 — scalar results pass through _apply_type_rules unchanged.
+# - Expected: result is not a _VecBase subclass.
+
+## Test: test_array_function_plain_ndarray_passthrough
+# - Goal: Verify that NumPy functions called with only plain ndarrays do not
+#         produce nemopy types.
+# - Source: Issue #50 — __array_function__ only dispatches for _VecBase inputs.
+# - Expected: type(result) is np.ndarray.
+
+
+class TestArrayFunction:
+
+    def test_array_function_linalg_solve(self):
+        """np.linalg.solve(Mat, ColVec) returns ColVec with correct values."""
+        A = Mat(np.array([[2, 1], [5, 3]], dtype=float))
+        b = ColVec(np.array([[4], [7]], dtype=float))
+        x = np.linalg.solve(A, b)
+        assert isinstance(x, ColVec)
+        assert x.shape == (2, 1)
+        np.testing.assert_allclose(np.asarray(x), np.array([[1], [2]]))
+
+    def test_array_function_linalg_eig(self):
+        """np.linalg.eig(Mat) returns (plain ndarray, Mat) tuple."""
+        A = Mat(np.array([[1, 0], [0, 2]], dtype=float))
+        vals, vecs = np.linalg.eig(A)
+        assert not isinstance(vals, _VecBase)
+        assert isinstance(vecs, Mat)
+        assert vecs.shape == (2, 2)
+
+    def test_array_function_sort(self):
+        """np.sort(ColVec, axis=0) returns ColVec with sorted values."""
+        u = ColVec(np.array([[3], [1], [2]], dtype=float))
+        result = np.sort(u, axis=0)
+        assert isinstance(result, ColVec)
+        assert result.shape == (3, 1)
+        np.testing.assert_array_equal(
+            np.asarray(result), np.array([[1], [2], [3]])
+        )
+
+    def test_array_function_concatenate(self):
+        """np.concatenate([ColVec, ColVec], axis=0) returns ColVec."""
+        u = ColVec(np.array([[1], [2]], dtype=float))
+        v = ColVec(np.array([[3], [4]], dtype=float))
+        result = np.concatenate([u, v], axis=0)
+        assert isinstance(result, ColVec)
+        assert result.shape == (4, 1)
+        np.testing.assert_array_equal(
+            np.asarray(result), np.array([[1], [2], [3], [4]])
+        )
+
+    def test_array_function_reshape(self):
+        """np.reshape(ColVec, (1, -1)) returns Mat."""
+        u = ColVec(np.array([[1], [2], [3]], dtype=float))
+        result = np.reshape(u, (1, -1))
+        assert isinstance(result, Mat)
+        assert result.shape == (1, 3)
+
+    def test_array_function_scalar_result(self):
+        """np.sum(ColVec) returns a plain scalar, not a _VecBase subclass."""
+        u = ColVec(np.array([[1], [2], [3]], dtype=float))
+        result = np.sum(u)
+        assert not isinstance(result, _VecBase)
+
+    def test_array_function_plain_ndarray_passthrough(self):
+        """NumPy function on plain ndarray does not produce nemopy types."""
+        a = np.array([[3], [1], [2]], dtype=float)
+        result = np.sort(a, axis=0)
+        assert type(result) is np.ndarray
+        assert not isinstance(result, _VecBase)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -788,8 +788,8 @@ class TestArrayFunction:
 
     def test_array_function_linalg_solve(self):
         """np.linalg.solve(Mat, ColVec) returns ColVec with correct values."""
-        A = Mat(np.array([[2, 1], [5, 3]], dtype=float))
-        b = ColVec(np.array([[4], [7]], dtype=float))
+        A = Mat(np.array([[1, 2], [3, 5]], dtype=float))
+        b = ColVec(np.array([[5], [13]], dtype=float))
         x = np.linalg.solve(A, b)
         assert isinstance(x, ColVec)
         assert x.shape == (2, 1)


### PR DESCRIPTION
## Summary

Implements `__array_function__` on `_VecBase` so that non-ufunc NumPy functions automatically preserve `ColVec`/`Mat` types via the existing `_apply_type_rules` shape→type mapper.

**Before:** `np.linalg.solve(A, b)` returned plain `ndarray` — users had to manually re-wrap with `ColVec(...)`.
**After:** `np.linalg.solve(A, b)` returns `ColVec` automatically when the output shape is `(n, 1)`.

### What changed

- Added `HANDLED_FUNCTIONS` dict and `implements` decorator as escape-hatch infrastructure for future per-function overrides
- Added `_strip_vecbase` helper to recursively convert `_VecBase` instances to plain `ndarray` in nested args (needed for `np.concatenate([u, v])` where arrays are inside a list)
- Added `__array_function__` method on `_VecBase` (unconditional — NEP 18 is stable since NumPy 1.17, project requires ≥1.20)
- Added 7 tests covering: `np.linalg.solve`, `np.linalg.eig` (tuple result), `np.sort`, `np.concatenate`, `np.reshape`, `np.sum` (scalar), and plain ndarray passthrough

### Design note

DESIGN.md §11 says "NumPy functions return plain ndarray." This PR extends that behavior per Issue #50's specification from the repo owner. The `HANDLED_FUNCTIONS` dict is empty in this PR — the default path handles all NumPy functions generically by stripping nemopy types, calling the real function, then applying type rules to the output.

Satisfies: Issue #50
Files modified: `nemopy/_core.py`, `tests/test_core.py`

## Test plan

- [x] 7 new tests in `TestArrayFunction` class all pass
- [x] Full test suite (100 passed, 3 skipped) — no regressions
- [x] Tests written first and verified to fail before implementation (red-green)
- [x] Cleanup audit passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLpAXJA8x86VP4SWYhdZe3)_