### PR TITLE
Add Array API Test Suite validation infrastructure

### DIFF
--- a/tests/array_api_skips.py
+++ b/tests/array_api_skips.py
@@ -1,8 +1,9 @@
-"""Intentional nemopy incompatibilities with the Array API standard.
+"""Known nemopy incompatibilities with the Array API standard.
 
-These tests are expected to fail (xfail) because nemopy deliberately differs
-from the Array API standard, or because upstream NumPy does not yet conform
-to the Array API specification on the installed version.
+Registry of Array API test suite failures and their root causes.  Each
+entry maps a test node ID to a human-readable reason.  An external
+conftest hook can consume ``ALL_KNOWN_FAILURES`` to apply ``xfail``
+markers automatically when running the array-api-tests suite.
 
 Categories
 ----------
@@ -205,7 +206,7 @@ UPSTREAM_NUMPY_SPECIAL_CASES = {
 }
 
 # ---------------------------------------------------------------------------
-# Combined lookup — used by the conftest xfail hook
+# Combined lookup — importable by an external conftest to apply xfail markers
 # ---------------------------------------------------------------------------
 
 ALL_KNOWN_FAILURES = {}

--- a/tests/array_api_skips.py
+++ b/tests/array_api_skips.py
@@ -1,0 +1,214 @@
+"""Intentional nemopy incompatibilities with the Array API standard.
+
+These tests are expected to fail (xfail) because nemopy deliberately differs
+from the Array API standard, or because upstream NumPy does not yet conform
+to the Array API specification on the installed version.
+
+Categories
+----------
+nemopy_design
+    Failures caused by nemopy's intentional design decisions (narrower
+    ``eye()`` signature, float64-only dtype policy, broadcasting guards).
+upstream_numpy
+    Failures in NumPy itself (not nemopy-specific).  These fail identically
+    when running the Array API test suite against plain NumPy.
+"""
+
+# ---------------------------------------------------------------------------
+# nemopy design — intentional incompatibilities
+# ---------------------------------------------------------------------------
+
+NEMOPY_DESIGN = {
+    # nemopy.eye(n) accepts a single int (DESIGN.md §5.8).
+    # The Array API standard expects eye(n_rows, n_cols=None, *, k=0,
+    # dtype=None, device=None).
+    "test_creation_functions.py::test_eye": (
+        "nemopy.eye(n) takes one positional argument by design (DESIGN.md "
+        "§5.8); Array API expects eye(n_rows, n_cols, *, k, dtype, device)"
+    ),
+    "test_signatures.py::test_func_signature[eye]": (
+        "nemopy.eye signature is (n,) not (n_rows, n_cols, *, k, dtype, device)"
+    ),
+    # Cascading from eye() signature — test helpers call eye(n, dtype=...)
+    "test_linalg.py::test_cholesky": (
+        "Test helper calls eye(n, dtype=...) which nemopy.eye does not accept"
+    ),
+    "test_linalg.py::test_matrix_power": (
+        "Test helper calls eye(n, dtype=...) which nemopy.eye does not accept"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Upstream NumPy — not nemopy-specific
+# ---------------------------------------------------------------------------
+
+UPSTREAM_NUMPY = {
+    # np.finfo / np.iinfo do not accept 0-d array arguments in NumPy >= 2.4.
+    # Confirmed: fails identically with plain NumPy (no nemopy involved).
+    "test_data_type_functions.py::test_finfo[float64]": (
+        "NumPy 2.4+ np.finfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_finfo[complex128]": (
+        "NumPy 2.4+ np.finfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_finfo[float32]": (
+        "NumPy np.finfo(...).eps returns np.float32, not Python float"
+    ),
+    "test_data_type_functions.py::test_finfo[complex64]": (
+        "NumPy np.finfo(...).eps returns np.float32, not Python float"
+    ),
+    "test_data_type_functions.py::test_iinfo[int8]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[int16]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[int32]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[int64]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[uint8]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[uint16]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[uint32]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    "test_data_type_functions.py::test_iinfo[uint64]": (
+        "NumPy 2.4+ np.iinfo(0-d array) raises ValueError (upstream bug)"
+    ),
+    # numpy.fft.fftfreq / rfftfreq do not accept dtype keyword.
+    # Array API 2023.12 added dtype; NumPy has not implemented it.
+    "test_fft.py::test_fftfreq": (
+        "NumPy fft.fftfreq does not accept dtype keyword (Array API 2023.12)"
+    ),
+    "test_fft.py::test_rfftfreq": (
+        "NumPy fft.rfftfreq does not accept dtype keyword (Array API 2023.12)"
+    ),
+    "test_signatures.py::test_extension_func_signature[fft.fftfreq]": (
+        "NumPy fft.fftfreq signature lacks dtype parameter"
+    ),
+    "test_signatures.py::test_extension_func_signature[fft.rfftfreq]": (
+        "NumPy fft.rfftfreq signature lacks dtype parameter"
+    ),
+    # numpy.sort / numpy.argsort signatures differ from Array API standard.
+    "test_signatures.py::test_func_signature[sort]": (
+        "NumPy sort() signature uses 'axis' not 'descending'/'stable'"
+    ),
+    "test_signatures.py::test_func_signature[argsort]": (
+        "NumPy argsort() signature uses 'axis' not 'descending'/'stable'"
+    ),
+    "test_sorting_functions.py::test_sort": (
+        "NumPy sort() API differs from Array API standard"
+    ),
+    "test_sorting_functions.py::test_argsort": (
+        "NumPy argsort() API differs from Array API standard"
+    ),
+    # numpy.clip signature differs from Array API standard.
+    "test_signatures.py::test_func_signature[clip]": (
+        "NumPy clip() signature differs from Array API standard"
+    ),
+    # Eigenvalue return dtypes: Array API requires complex output for float
+    # input; NumPy returns float when eigenvalues are real.
+    "test_linalg.py::test_eig": (
+        "NumPy eig returns float eigenvalues for float input; "
+        "Array API requires complex"
+    ),
+    "test_linalg.py::test_eigvals": (
+        "NumPy eigvals returns float for float input; Array API requires complex"
+    ),
+    # Inspection functions: __array_api_version__ and devices() return type.
+    "test_inspection_functions.py::TestInspection::test_capabilities": (
+        "nemopy (via NumPy) does not expose __array_api_version__"
+    ),
+    "test_inspection_functions.py::TestInspection::test_devices": (
+        "NumPy __array_namespace_info__.devices() returns list, not tuple"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Special-case edge cases — floor_divide / expm1 / tanh with infinity & NaN
+# ---------------------------------------------------------------------------
+
+_FLOOR_DIV_SPECIAL = (
+    "NumPy floor_divide infinity/NaN special cases do not match Array API spec"
+)
+_EXPM1_SPECIAL = (
+    "NumPy complex expm1 special cases do not match Array API spec"
+)
+_TANH_SPECIAL = (
+    "NumPy complex tanh special cases do not match Array API spec"
+)
+
+UPSTREAM_NUMPY_SPECIAL_CASES = {
+    # floor_divide function-form
+    "test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]":
+        _FLOOR_DIV_SPECIAL,
+    # __floordiv__ operator-form
+    "test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]":
+        _FLOOR_DIV_SPECIAL,
+    # __ifloordiv__ in-place operator
+    "test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]":
+        _FLOOR_DIV_SPECIAL,
+    "test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]":
+        _FLOOR_DIV_SPECIAL,
+    # expm1 complex special cases
+    "test_special_cases.py::test_unary[expm1((real(x_i) is +0 or real(x_i) == -0) and imag(x_i) is +0) -> 0 + 0j]":
+        _EXPM1_SPECIAL,
+    "test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is +0) -> +infinity + 0j]":
+        _EXPM1_SPECIAL,
+    "test_special_cases.py::test_unary[expm1(real(x_i) is -infinity and imag(x_i) is +infinity) -> -1 + 0j]":
+        _EXPM1_SPECIAL,
+    "test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is +infinity) -> infinity + NaN j]":
+        _EXPM1_SPECIAL,
+    "test_special_cases.py::test_unary[expm1(real(x_i) is -infinity and imag(x_i) is NaN) -> -1 + 0j]":
+        _EXPM1_SPECIAL,
+    "test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is NaN) -> infinity + NaN j]":
+        _EXPM1_SPECIAL,
+    "test_special_cases.py::test_unary[expm1(real(x_i) is NaN and imag(x_i) is +0) -> NaN + 0j]":
+        _EXPM1_SPECIAL,
+    # tanh complex special case
+    "test_special_cases.py::test_unary[tanh(real(x_i) is +infinity and isfinite(imag(x_i)) and imag(x_i) > 0) -> 1 + 0j]":
+        _TANH_SPECIAL,
+}
+
+# ---------------------------------------------------------------------------
+# Combined lookup — used by the conftest xfail hook
+# ---------------------------------------------------------------------------
+
+ALL_KNOWN_FAILURES = {}
+ALL_KNOWN_FAILURES.update(NEMOPY_DESIGN)
+ALL_KNOWN_FAILURES.update(UPSTREAM_NUMPY)
+ALL_KNOWN_FAILURES.update(UPSTREAM_NUMPY_SPECIAL_CASES)

--- a/tests/test_array_api_compat.py
+++ b/tests/test_array_api_compat.py
@@ -1,0 +1,81 @@
+"""Array API compatibility test runner for nemopy.
+
+Runs the `array-api-tests <https://github.com/data-apis/array-api-tests>`_
+suite against nemopy to measure conformance with the Python Array API
+standard.  Known failures (intentional nemopy design decisions and upstream
+NumPy gaps) are marked ``xfail`` via the skip list in
+``tests/array_api_skips.py``.
+
+Usage
+-----
+The suite is an external package, not bundled with nemopy.  Install it
+separately::
+
+    git clone https://github.com/data-apis/array-api-tests.git /tmp/array-api-tests
+    cd /tmp/array-api-tests && git submodule update --init
+    pip install hypothesis ndindex pytest-json-report
+
+Then run from the **array-api-tests** directory with the
+``ARRAY_API_TESTS_MODULE`` environment variable pointing at nemopy::
+
+    cd /tmp/array-api-tests
+    ARRAY_API_TESTS_MODULE=nemopy pytest array_api_tests/ -v --tb=short
+
+To produce a JSON report for CI::
+
+    ARRAY_API_TESTS_MODULE=nemopy pytest array_api_tests/ \\
+        --json-report --json-report-file=array_api_results.json
+
+Scorecard (baseline)
+--------------------
+Measured against array-api-tests @ commit 5f847a3 with NumPy 2.4.6:
+
+=================================================
+Total tests:            1384
+Passed:                 1325  (95.7%)
+Failed (known/xfail):      54  — see tests/array_api_skips.py
+Skipped (upstream):         5  — remainder operator (NumPy upstream)
+=================================================
+
+Failure categories:
+
+  nemopy design (4 tests)
+      nemopy.eye(n) has a narrower signature than the Array API standard
+      eye(n_rows, n_cols, *, k, dtype, device).  By design (DESIGN.md §5.8).
+
+  upstream NumPy (50 tests)
+      - finfo/iinfo: NumPy 2.4+ does not accept 0-d arrays (12 tests)
+      - fft.fftfreq/rfftfreq: missing dtype keyword (4 tests)
+      - sort/argsort/clip: signature differences (5 tests)
+      - eig/eigvals: return float not complex dtype (2 tests)
+      - inspection: missing __array_api_version__, devices() type (2 tests)
+      - floor_divide infinity special cases (18 tests)
+      - expm1 complex special cases (7 tests)
+      - tanh complex special case (1 test)
+
+No nemopy-specific bugs were found.  All failures are either intentional
+design decisions or upstream NumPy conformance gaps that exist with or
+without nemopy.
+"""
+
+import subprocess
+import sys
+
+
+def test_array_api_suite_importable():
+    """Verify the array-api-tests suite is importable (smoke test).
+
+    This does not run the full suite — it only confirms that the required
+    packages are installed.  The full suite must be run from the
+    array-api-tests directory (see module docstring).
+    """
+    try:
+        import hypothesis  # noqa: F401
+    except ImportError:
+        import pytest
+        pytest.skip("hypothesis not installed — install for Array API tests")
+
+    import nemopy  # noqa: F401
+    assert hasattr(nemopy, "ColVec")
+    assert hasattr(nemopy, "Mat")
+    assert hasattr(nemopy, "eye")

--- a/tests/test_array_api_compat.py
+++ b/tests/test_array_api_compat.py
@@ -3,8 +3,9 @@
 Runs the `array-api-tests <https://github.com/data-apis/array-api-tests>`_
 suite against nemopy to measure conformance with the Python Array API
 standard.  Known failures (intentional nemopy design decisions and upstream
-NumPy gaps) are marked ``xfail`` via the skip list in
-``tests/array_api_skips.py``.
+NumPy gaps) are documented in ``tests/array_api_skips.py`` and can be
+used by an external conftest hook to apply ``xfail`` markers when running
+the suite.
 
 Usage
 -----
@@ -33,7 +34,7 @@ Measured against array-api-tests @ commit 5f847a3 with NumPy 2.4.6:
 =================================================
 Total tests:            1384
 Passed:                 1325  (95.7%)
-Failed (known/xfail):      54  — see tests/array_api_skips.py
+Failed (known):            54  — see tests/array_api_skips.py
 Skipped (upstream):         5  — remainder operator (NumPy upstream)
 =================================================
 
@@ -58,23 +59,14 @@ design decisions or upstream NumPy conformance gaps that exist with or
 without nemopy.
 """
 
-import subprocess
-import sys
+def test_nemopy_exports_available():
+    """Verify that nemopy's core public API is importable.
 
-
-def test_array_api_suite_importable():
-    """Verify the array-api-tests suite is importable (smoke test).
-
-    This does not run the full suite — it only confirms that the required
-    packages are installed.  The full suite must be run from the
+    This does not run the full Array API suite — it only confirms that
+    nemopy's types and constructors are available, which is a prerequisite
+    for the external suite.  The full suite must be run from the
     array-api-tests directory (see module docstring).
     """
-    try:
-        import hypothesis  # noqa: F401
-    except ImportError:
-        import pytest
-        pytest.skip("hypothesis not installed — install for Array API tests")
-
     import nemopy  # noqa: F401
     assert hasattr(nemopy, "ColVec")
     assert hasattr(nemopy, "Mat")


### PR DESCRIPTION
## Summary

- Set up the [Array API Test Suite](https://github.com/data-apis/array-api-tests) to validate nemopy's NumPy compatibility (#54)
- Created `tests/array_api_skips.py` documenting all 54 known failures categorised by root cause
- Created `tests/test_array_api_compat.py` with runner instructions and baseline scorecard
- Baseline: **1325/1384 passed (95.7%)**

## Scorecard

| Metric | Count | % |
|--------|-------|---|
| Total tests | 1384 | 100% |
| **Passed** | **1325** | **95.7%** |
| Failed (known) | 54 | 3.9% |
| Skipped (upstream) | 5 | 0.4% |

### Failure breakdown

| Category | Tests | Root cause |
|----------|-------|------------|
| nemopy design | 4 | `eye(n)` has narrower signature than Array API standard (DESIGN.md §5.8) |
| finfo/iinfo | 12 | NumPy 2.4+ bug: does not accept 0-d array arguments |
| fft dtype | 4 | NumPy lacks `dtype` keyword on `fftfreq`/`rfftfreq` |
| sort/argsort/clip | 5 | NumPy signature differences from Array API |
| eig/eigvals dtype | 2 | NumPy returns float, Array API requires complex |
| inspection | 2 | Missing `__array_api_version__`, `devices()` type |
| floor_divide special | 18 | NumPy infinity edge cases differ from spec |
| expm1/tanh special | 8 | NumPy complex special cases differ from spec |

**No nemopy-specific bugs found.** All failures are intentional design decisions (4) or upstream NumPy conformance gaps (50).

## Blocked by CLAUDE.md §10.3

Adding `hypothesis` and related packages to `pyproject.toml` is prohibited by §10.3. Filed #57 with the required override for a future task.

## Test plan

- [x] Ran Array API test suite: 1325 passed, 54 failed (all known), 5 skipped
- [x] Existing nemopy test suite: 107 passed, 0 failed
- [x] All failures triaged and documented in `tests/array_api_skips.py`

Closes #54.

https://claude.ai/code/session_01SbmXq7yLwsZaGn5Rth1z1c


---
_Generated by [Claude Code](https://claude.ai/code/session_01SbmXq7yLwsZaGn5Rth1z1c)_