### PR TITLE
chore: add SessionStart hook for Claude Code web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+pip install -e ".[dev]"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Installs project dev dependencies (numpy, pytest, pandas, polars, sphinx) via `pip install -e ".[dev]"` when running in a remote Claude Code environment.

https://claude.ai/code/session_01L2F6ZJnrA9AsPr5qvweGiJ