### PR TITLE
fix(core): handle boolean mask indexing in Mat.__getitem__

### DIFF
--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -681,6 +681,9 @@ class Mat(_VecBase):
         --------
         ColVec.__getitem__ : Indexing semantics for column vectors.
         """
+        if isinstance(key, np.ndarray) and key.dtype == np.bool_:
+            return np.asarray(super().__getitem__(key))
+
         result = super().__getitem__(key)
 
         if not isinstance(result, np.ndarray) or result.ndim == 0:
@@ -693,7 +696,6 @@ class Mat(_VecBase):
                     return ColVec(result.reshape(-1, 1))
                 if isinstance(row_key, (int, np.integer)):
                     return Mat(result.reshape(1, -1))
-            # For ambiguous 1D indexing, preserve column-first convention.
             return ColVec(result.reshape(-1, 1))
 
         if result.ndim == 2:

--- a/tests/numpy_compat/conftest.py
+++ b/tests/numpy_compat/conftest.py
@@ -24,11 +24,6 @@ NEMOPY_XFAILS_EXACT = {
         "nemopy ShapeError: shape guard blocks 1D vs (n,1) subtraction "
         "inside numpy.testing (intentional guardrail, §7.1)",
 
-    # ---- nemopy __getitem__ override interferes with numpy.testing ----
-    "TestSVD::test_empty_identity":
-        "nemopy Mat.__getitem__ boolean indexing override conflicts with "
-        "numpy.testing.assert_equal internal comparison",
-
     # ---- nemopy eye() signature (DESIGN.md §5.8) ----
     "TestVdot::test_basic":
         "nemopy eye() does not accept dtype kwarg (§5.8: eye(n) only)",
@@ -72,12 +67,6 @@ NEMOPY_XFAILS_EXACT = {
 
 NEMOPY_XFAILS_PATTERN = {
     # Parametrized tests matched by pattern (substring match OK here)
-    "TestMatrixPower::test_power_is_zero":
-        "nemopy Mat.__getitem__ boolean indexing override conflicts with "
-        "numpy.testing.assert_equal internal comparison",
-    "TestMatrixPower::test_power_is_minus_one":
-        "nemopy Mat.__getitem__ boolean indexing override conflicts with "
-        "numpy.testing.assert_equal internal comparison",
     "TestFloatExceptions::test_floating_exceptions":
         "NumPy API change: finfo._machar removed after v2.1",
     "TestIO::test_malformed":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -487,6 +487,35 @@ class TestMatGetItem:
             np.asarray(result), np.array([[76.0], [228.0], [380.0]])
         )
 
+    ## Test: test_mat_getitem_boolean_mask_returns_plain_ndarray
+    # - Goal: Boolean mask indexing on a Mat returns a plain 1D ndarray,
+    #         matching NumPy's flattening behaviour, not a ColVec.
+    # - Source: DESIGN.md §6.3 — boolean column masks use tuple keys
+    #           (A[:, mask]); a flat boolean mask is unspecified and should
+    #           fall through to ndarray behaviour.
+    # - Expected: 1D ndarray of matching elements.
+    def test_mat_getitem_boolean_mask_returns_plain_ndarray(self):
+        """Flat boolean mask on Mat returns plain 1D ndarray, not ColVec."""
+        A = Mat(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float))
+        mask = A > 5
+        result = A[mask]
+        assert type(result) is np.ndarray
+        assert result.ndim == 1
+        np.testing.assert_array_equal(result, np.array([6.0, 7.0, 8.0, 9.0]))
+
+    ## Test: test_mat_numpy_testing_assert_equal_works
+    # - Goal: numpy.testing.assert_equal works with Mat objects without
+    #         raising IndexError from boolean indexing conflicts.
+    # - Source: Issue #69 — assert_equal internally does A[bool_mask] which
+    #           must not be intercepted by Mat.__getitem__ column semantics.
+    # - Expected: No error raised.
+    def test_mat_numpy_testing_assert_equal_works(self):
+        """numpy.testing.assert_equal works with Mat objects."""
+        from numpy.linalg import matrix_power
+        M = Mat(np.eye(4))
+        mz = matrix_power(M, 0)
+        np.testing.assert_equal(mz, np.eye(4))
+
     def test_mat_det_identity_returns_float_one(self):
         """Mat.det(identity) returns 1.0 as Python float."""
         A = Mat(np.eye(3))


### PR DESCRIPTION
## Summary

- Flat boolean ndarray masks on `Mat` now fall through to plain ndarray indexing instead of being reshaped to `ColVec`. This fixes `numpy.testing.assert_equal` which internally does `A[bool_mask]` to extract differing elements.
- Tuple-key boolean column masks (`A[:, mask]`) are unaffected — they still follow the §6.3 column-extraction contract.
- Removes 31 xfails from the NumPy compat suite (`TestMatrixPower::test_power_is_zero` ×16, `test_power_is_minus_one` ×14, `TestSVD::test_empty_identity`).

**DESIGN.md section:** §6.3 (Mat Column Extraction). Flat boolean masks are unspecified in §6.3 (which only covers tuple-key `A[:, mask]`), so they correctly fall through to NumPy's default flattening behaviour.

**Assumptions:** A bare boolean ndarray key always indicates flattening intent (NumPy semantics), not column selection.

## Test plan

- [x] `test_mat_getitem_boolean_mask_returns_plain_ndarray` — verifies `A[mask]` returns 1D plain ndarray
- [x] `test_mat_numpy_testing_assert_equal_works` — verifies `assert_equal(matrix_power(M, 0), eye(4))` succeeds
- [x] Full test suite: 16,043 passed, 0 failures
- [x] Red-green verified: both tests fail before fix, pass after

Closes #69.

https://claude.ai/code/session_01Ue6Zox1F9GMDKUTpW6eu7h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue6Zox1F9GMDKUTpW6eu7h)_