### PR TITLE
feat(constructors): add dtype, M, k kwargs to eye()

### DIFF
--- a/nemopy/_constructors.py
+++ b/nemopy/_constructors.py
@@ -340,22 +340,30 @@ def mat(*args):
     return Mat(stacked)
 
 
-def eye(n):
-    """Construct the n × n identity matrix.
+def eye(n, M=None, k=0, dtype=None):
+    """Construct an identity matrix.
 
-    Wraps ``numpy.eye(n)`` as a ``Mat``, ensuring the identity enters nemopy
-    expressions with the correct type label. More concise than
-    ``Mat(np.eye(n))`` and avoids importing NumPy at call sites.
+    Wraps ``numpy.eye`` as a ``Mat``, ensuring the identity enters nemopy
+    expressions with the correct type label. Accepts NumPy-compatible
+    keyword arguments for non-square and offset-diagonal identities.
 
     Parameters
     ----------
     n : int
-        Dimension of the identity matrix. Must be a positive integer.
+        Number of rows.
+    M : int, optional
+        Number of columns. Defaults to ``n`` (square).
+    k : int, optional
+        Diagonal offset. ``0`` (default) is the main diagonal, positive
+        values shift up, negative values shift down.
+    dtype : dtype, optional
+        Accepted for NumPy compatibility but ignored — the result is
+        always promoted to ``float64`` per nemopy convention.
 
     Returns
     -------
     Mat
-        Shape ``(n, n)`` identity matrix with dtype ``float64``.
+        Identity matrix with dtype ``float64``.
 
     Examples
     --------
@@ -381,7 +389,7 @@ def eye(n):
     mat : Column-first matrix constructor.
     Mat : Direct constructor for 2D arrays.
     """
-    return Mat(np.eye(int(n)))
+    return Mat(np.eye(int(n), M=M, k=k))
 
 
 def as_col(x):

--- a/tests/numpy_compat/conftest.py
+++ b/tests/numpy_compat/conftest.py
@@ -29,10 +29,6 @@ NEMOPY_XFAILS_EXACT = {
         "nemopy Mat.__getitem__ boolean indexing override conflicts with "
         "numpy.testing.assert_equal internal comparison",
 
-    # ---- nemopy eye() signature (DESIGN.md §5.8) ----
-    "TestVdot::test_basic":
-        "nemopy eye() does not accept dtype kwarg (§5.8: eye(n) only)",
-
     # ---- NumPy v2.1->v2.4 API changes (not nemopy-related) ----
     "TestNonarrayArgs::test_reshape_shape_arg":
         "NumPy API change: reshape() 'newshape' kwarg removed in v2.4",

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -197,6 +197,30 @@ class TestEyeConstructor:
         assert I.shape == (3, 3)
         np.testing.assert_array_equal(np.asarray(I), np.eye(3))
 
+    ## Test: test_eye_accepts_dtype_kwarg
+    # - Goal: eye(n, dtype=...) accepts a dtype kwarg without raising
+    #         TypeError, always producing float64 per §3.
+    # - Source: Issue #68 — np.eye(n, dtype=...) through nemopy fails.
+    # - Expected: No TypeError; result dtype is float64; shape is (n,n).
+    def test_eye_accepts_dtype_kwarg(self):
+        """eye(n, dtype=...) accepts dtype kwarg, result is always float64."""
+        I = eye(3, dtype=np.float32)
+        assert isinstance(I, Mat)
+        assert I.shape == (3, 3)
+        assert I.dtype == np.float64
+
+    ## Test: test_eye_accepts_M_and_k_kwargs
+    # - Goal: eye(n, M=m, k=k) accepts NumPy-compatible kwargs.
+    # - Source: Issue #68 — fuller compat with np.eye() signature.
+    # - Expected: Non-square identity with offset diagonal.
+    def test_eye_accepts_M_and_k_kwargs(self):
+        """eye(n, M=m, k=k) produces non-square identity with offset."""
+        I = eye(3, M=4, k=1)
+        assert isinstance(I, Mat)
+        assert I.shape == (3, 4)
+        expected = np.eye(3, M=4, k=1)
+        assert np.array_equal(np.asarray(I), expected)
+
 
 class TestAsColConstructor:
     def test_as_col_from_list(self):


### PR DESCRIPTION
## Summary

- `eye()` now accepts `dtype`, `M`, and `k` keyword arguments for NumPy API compatibility.
- `dtype` is accepted but ignored — result is always `float64` per §3 convention (Mat constructor promotes).
- `M` and `k` are passed through to `np.eye()` for non-square and offset-diagonal identities.
- Removes 1 xfail (`TestVdot::test_basic`).

**DESIGN.md section:** §5.8 (eye specification). The spec only specifies `eye(n)` but is silent on additional kwargs. Adding them is a strict superset — existing calls are unaffected.

## Test plan

- [x] `test_eye_accepts_dtype_kwarg` — `eye(3, dtype=np.float32)` produces `Mat(3,3)` with `float64`
- [x] `test_eye_accepts_M_and_k_kwargs` — `eye(3, M=4, k=1)` produces correct non-square identity
- [x] Existing `test_eye_identity` still passes
- [x] Red-green verified

Closes #68.

https://claude.ai/code/session_01Ue6Zox1F9GMDKUTpW6eu7h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue6Zox1F9GMDKUTpW6eu7h)_