### PR TITLE
chore(deps): add array-api test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,14 @@ docs = [
     "sphinx>=4.0",
     "sphinx-rtd-theme>=1.0",
 ]
+array-api = [
+    "hypothesis>=6.151.0",
+    "ndindex>=1.8",
+    "pytest-json-report",
+]
 dev = [
     "pytest>=7.0",
+    "hypothesis>=6.151.0",
     "pandas>=1.0",
     "polars>=0.19",
     "sphinx>=4.0",


### PR DESCRIPTION
## Summary

- Adds `[array-api]` optional dependency group with `hypothesis>=6.151.0`, `ndindex>=1.8`, `pytest-json-report`
- Adds `hypothesis>=6.151.0` to the `[dev]` group
- Completes the Array API test infrastructure from #54

## Notes

`array-api-tests` itself is not on PyPI and must be installed from Git (documented in issue #57). A CI workflow step is the appropriate place for that.

## Test plan

- [x] `pyproject.toml` syntax is valid
- [x] No source code changes

Closes #57.

https://claude.ai/code/session_01Ue6Zox1F9GMDKUTpW6eu7h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue6Zox1F9GMDKUTpW6eu7h)_