### PR TITLE
feat(elimination): add Gaussian elimination and row echelon forms

### DIFF
--- a/nemopy/__init__.py
+++ b/nemopy/__init__.py
@@ -17,6 +17,7 @@ from nemopy._constructors import _c, _m, mat, eye, as_col, as_mat  # noqa: F401
 from nemopy import _operators  # noqa: F401
 from nemopy import _stats  # noqa: F401
 from nemopy import _decompositions  # noqa: F401
+from nemopy import _elimination  # noqa: F401
 
 __all__ = [
     "_c",

--- a/nemopy/_elimination.py
+++ b/nemopy/_elimination.py
@@ -1,0 +1,280 @@
+"""Gaussian elimination and row echelon forms as Mat methods (issue #85).
+
+The production path runs in ``_rust_core.linalg`` (REF/RREF, fused
+Gaussian solve); the NumPy fallback mirrors its semantics per §20.1. The
+step-by-step ``ref_steps()`` pedagogy mode stays in Python by design.
+RREF is primarily valuable for exact/small systems and teaching; for
+large systems prefer the LU-backed solvers (numerical-stability note in
+issue #85).
+"""
+
+import numpy as np
+
+from nemopy import _core
+from nemopy._core import ColVec, Mat, ShapeError
+
+
+def _default_tol(a):
+    scale = max(1.0, float(np.abs(a).max())) if a.size else 1.0
+    return np.finfo(float).eps * max(a.shape) * scale
+
+
+def _ref_fallback(a, partial):
+    m, n = a.shape
+    r = a.copy()
+    tol = _default_tol(a)
+    row = 0
+    for col in range(n):
+        if row >= m:
+            break
+        if partial:
+            p = row + int(np.argmax(np.abs(r[row:, col])))
+        else:
+            p = row
+        if abs(r[p, col]) <= tol:
+            if not partial and np.any(np.abs(r[row + 1:, col]) > tol):
+                raise ValueError(
+                    f'zero pivot in column {col} requires a row exchange; '
+                    f'use pivot="partial"'
+                )
+            continue
+        if p != row:
+            r[[row, p], :] = r[[p, row], :]
+        f = r[row + 1:, col] / r[row, col]
+        r[row + 1:, col:] -= np.outer(f, r[row, col:])
+        r[row + 1:, col] = 0.0
+        row += 1
+    return r
+
+
+def _rref_fallback(a):
+    m, n = a.shape
+    r = a.copy()
+    tol = _default_tol(a)
+    pivots = []
+    row = 0
+    for col in range(n):
+        if row >= m:
+            break
+        p = row + int(np.argmax(np.abs(r[row:, col])))
+        if abs(r[p, col]) <= tol:
+            continue
+        if p != row:
+            r[[row, p], :] = r[[p, row], :]
+        r[row, :] /= r[row, col]
+        r[row, col] = 1.0
+        others = [i for i in range(m) if i != row]
+        f = r[others, col]
+        r[others, :] -= np.outer(f, r[row, :])
+        r[others, col] = 0.0
+        pivots.append(col)
+        row += 1
+    r[r == 0.0] = 0.0
+    return r, pivots
+
+
+def _mat_ref(self, pivot="partial"):
+    """Row echelon form via forward elimination.
+
+    Parameters
+    ----------
+    pivot : str, optional
+        ``"partial"`` (default) for partial pivoting (row swaps),
+        ``"none"`` for classic unpivoted elimination (pedagogical use).
+
+    Raises
+    ------
+    ValueError
+        For an unknown pivot strategy, or when ``pivot="none"`` hits a
+        zero pivot that would require a row exchange.
+    """
+    if pivot not in ("partial", "none"):
+        raise ValueError(
+            f'pivot must be "partial" or "none", got {pivot!r}'
+        )
+    a = np.asarray(self)
+    rust = _core._RUST
+    if rust is not None:
+        return Mat(rust.ref_(a, pivot == "partial"))
+    return Mat(_ref_fallback(a, pivot == "partial"))
+
+
+def _mat_rref(self):
+    """Reduced row echelon form and pivot column indices.
+
+    Returns
+    -------
+    (Mat, tuple of int)
+        The canonical RREF and the pivot column indices.
+    """
+    a = np.asarray(self)
+    rust = _core._RUST
+    if rust is not None:
+        r, pivots = rust.rref(a)
+    else:
+        r, pivots = _rref_fallback(a)
+    return Mat(np.asarray(r)), tuple(int(p) for p in pivots)
+
+
+def _mat_rank(self):
+    """Rank as the number of RREF pivot columns (tolerance-aware)."""
+    return len(_mat_rref(self)[1])
+
+
+def _mat_nullspace(self):
+    """Null space basis vectors as Mat columns (from the RREF).
+
+    A full-rank matrix returns an empty ``(k, 0)`` Mat.
+    """
+    k = self.shape[1]
+    r, pivots = _mat_rref(self)
+    r = np.asarray(r)
+    free = [j for j in range(k) if j not in pivots]
+    basis = np.zeros((k, len(free)))
+    for idx, f in enumerate(free):
+        basis[f, idx] = 1.0
+        for i, p in enumerate(pivots):
+            basis[p, idx] = -r[i, f]
+    return Mat(basis)
+
+
+def _check_rhs(self, b, name):
+    b = np.asarray(b, dtype=float)
+    if b.ndim == 1:
+        b = b.reshape(-1, 1)
+    if b.ndim != 2 or b.shape[1] != 1 or b.shape[0] != self.shape[0]:
+        raise ShapeError(
+            f"{name}() requires b of shape ({self.shape[0]}, 1), "
+            f"got {b.shape}."
+        )
+    return b
+
+
+def _mat_gaussian_eliminate(self, b):
+    """Solve ``Ax = b`` by forward elimination + back substitution.
+
+    Raises
+    ------
+    ShapeError
+        If A is not square or b has the wrong shape.
+    ValueError
+        If A is singular to working precision.
+    """
+    if self.shape[0] != self.shape[1]:
+        raise ShapeError(
+            f"gaussian_eliminate() requires a square matrix, got shape "
+            f"{self.shape}."
+        )
+    a = np.asarray(self)
+    b = _check_rhs(self, b, "gaussian_eliminate")
+    rust = _core._RUST
+    if rust is not None:
+        x = rust.gauss_solve(a, b)
+        return ColVec(np.asarray(x).reshape(-1, 1))
+    w = np.hstack([a, b]).astype(float)
+    n = a.shape[0]
+    tol = _default_tol(a)
+    for k in range(n):
+        p = k + int(np.argmax(np.abs(w[k:, k])))
+        if abs(w[p, k]) <= tol:
+            raise ValueError("matrix is singular to working precision")
+        if p != k:
+            w[[k, p], :] = w[[p, k], :]
+        f = w[k + 1:, k] / w[k, k]
+        w[k + 1:, k:] -= np.outer(f, w[k, k:])
+    x = np.zeros(n)
+    for i in range(n - 1, -1, -1):
+        x[i] = (w[i, n] - w[i, i + 1:n] @ x[i + 1:]) / w[i, i]
+    return ColVec(x.reshape(-1, 1))
+
+
+def _mat_gauss_jordan(self, b=None):
+    """Full Gauss-Jordan elimination to RREF.
+
+    With no ``b``, returns the RREF of A as a Mat. With ``b``, solves
+    ``Ax = b`` via the RREF of the augmented system and returns the
+    solution ColVec.
+
+    Raises
+    ------
+    ShapeError
+        With ``b``: if A is not square or b has the wrong shape.
+    ValueError
+        With ``b``: if A is singular to working precision.
+    """
+    if b is None:
+        return _mat_rref(self)[0]
+    if self.shape[0] != self.shape[1]:
+        raise ShapeError(
+            f"gauss_jordan() requires a square matrix to solve, got shape "
+            f"{self.shape}."
+        )
+    b = _check_rhs(self, b, "gauss_jordan")
+    n = self.shape[0]
+    aug = Mat(np.hstack([np.asarray(self), b]))
+    r, pivots = _mat_rref(aug)
+    if tuple(p for p in pivots if p < n) != tuple(range(n)):
+        raise ValueError("matrix is singular to working precision")
+    return ColVec(np.asarray(r)[:, n:].copy())
+
+
+def _mat_augment(self, b):
+    """Augmented matrix ``[A | b]`` for manual elimination.
+
+    Raises
+    ------
+    ShapeError
+        If b's row count differs from A's.
+    """
+    b = np.asarray(b, dtype=float)
+    if b.ndim == 1:
+        b = b.reshape(-1, 1)
+    if b.shape[0] != self.shape[0]:
+        raise ShapeError(
+            f"augment() requires equal row counts, got {self.shape} "
+            f"and {b.shape}."
+        )
+    return Mat(np.hstack([np.asarray(self), b]))
+
+
+def _mat_ref_steps(self):
+    """Yield ``(Mat, description)`` pairs for each elimination step.
+
+    Pedagogical mode (issue #85): runs the partial-pivoting forward
+    elimination in Python, materializing a snapshot after every row
+    exchange and row update. The final snapshot equals ``self.ref()``.
+    """
+    a = np.asarray(self).copy()
+    m, n = a.shape
+    tol = _default_tol(a)
+    yield Mat(a.copy()), "start"
+    row = 0
+    for col in range(n):
+        if row >= m:
+            break
+        p = row + int(np.argmax(np.abs(a[row:, col])))
+        if abs(a[p, col]) <= tol:
+            continue
+        if p != row:
+            a[[row, p], :] = a[[p, row], :]
+            yield Mat(a.copy()), f"swap R{row + 1} and R{p + 1}"
+        for i in range(row + 1, m):
+            f = a[i, col] / a[row, col]
+            if f != 0.0:
+                a[i, col:] -= f * a[row, col:]
+                a[i, col] = 0.0
+                yield (
+                    Mat(a.copy()),
+                    f"R{i + 1} -> R{i + 1} - ({f:.6g})*R{row + 1}",
+                )
+        row += 1
+
+
+Mat.ref = _mat_ref
+Mat.rref = _mat_rref
+Mat.rank = _mat_rank
+Mat.nullspace = _mat_nullspace
+Mat.gaussian_eliminate = _mat_gaussian_eliminate
+Mat.gauss_jordan = _mat_gauss_jordan
+Mat.augment = _mat_augment
+Mat.ref_steps = _mat_ref_steps

--- a/nemopy/_rust_core/src/lib.rs
+++ b/nemopy/_rust_core/src/lib.rs
@@ -7,6 +7,7 @@
 use pyo3::prelude::*;
 
 mod decomp;
+mod linalg;
 mod ops;
 mod stats;
 
@@ -21,5 +22,6 @@ fn _rust_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     ops::register(m)?;
     stats::register(m)?;
     decomp::register(m)?;
+    linalg::register(m)?;
     Ok(())
 }

--- a/nemopy/_rust_core/src/linalg.rs
+++ b/nemopy/_rust_core/src/linalg.rs
@@ -1,0 +1,206 @@
+//! Elimination kernels (issue #85): REF, RREF with pivot tracking, and a
+//! fused Gaussian factor+solve. Blocked row operations stay in Rust; the
+//! pedagogical step-by-step mode lives in Python by design.
+
+use ndarray::{Array1, Array2, ArrayView2};
+use numpy::{PyArray1, PyArray2, PyReadonlyArray2, ToPyArray};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+fn default_tol(a: &ArrayView2<'_, f64>) -> f64 {
+    let scale = a.iter().fold(0.0f64, |m, &x| m.max(x.abs())).max(1.0);
+    f64::EPSILON * (a.nrows().max(a.ncols()) as f64) * scale
+}
+
+fn ref_impl(a: ArrayView2<'_, f64>, partial: bool) -> Result<Array2<f64>, String> {
+    let (m, n) = (a.nrows(), a.ncols());
+    let mut r = a.to_owned();
+    let tol = default_tol(&a);
+    let mut row = 0;
+    for col in 0..n {
+        if row >= m {
+            break;
+        }
+        let mut p = row;
+        if partial {
+            let mut best = r[(row, col)].abs();
+            for i in (row + 1)..m {
+                if r[(i, col)].abs() > best {
+                    best = r[(i, col)].abs();
+                    p = i;
+                }
+            }
+        }
+        if r[(p, col)].abs() <= tol {
+            if !partial {
+                let needed = ((row + 1)..m).any(|i| r[(i, col)].abs() > tol);
+                if needed {
+                    return Err(format!(
+                        "zero pivot in column {} requires a row exchange; \
+                         use pivot=\"partial\"",
+                        col
+                    ));
+                }
+            }
+            continue;
+        }
+        if p != row {
+            for j in 0..n {
+                r.swap((row, j), (p, j));
+            }
+        }
+        let piv = r[(row, col)];
+        for i in (row + 1)..m {
+            let f = r[(i, col)] / piv;
+            if f != 0.0 {
+                for j in col..n {
+                    r[(i, j)] -= f * r[(row, j)];
+                }
+            }
+            r[(i, col)] = 0.0;
+        }
+        row += 1;
+    }
+    Ok(r)
+}
+
+#[pyfunction(name = "ref_")]
+fn ref_py<'py>(
+    py: Python<'py>,
+    a: PyReadonlyArray2<'py, f64>,
+    partial: bool,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let a = a.as_array();
+    py.allow_threads(|| ref_impl(a, partial))
+        .map(|r| r.to_pyarray(py))
+        .map_err(PyValueError::new_err)
+}
+
+fn rref_impl(a: ArrayView2<'_, f64>) -> (Array2<f64>, Vec<usize>) {
+    let (m, n) = (a.nrows(), a.ncols());
+    let mut r = a.to_owned();
+    let tol = default_tol(&a);
+    let mut pivots = Vec::new();
+    let mut row = 0;
+    for col in 0..n {
+        if row >= m {
+            break;
+        }
+        let mut p = row;
+        let mut best = r[(row, col)].abs();
+        for i in (row + 1)..m {
+            if r[(i, col)].abs() > best {
+                best = r[(i, col)].abs();
+                p = i;
+            }
+        }
+        if best <= tol {
+            continue;
+        }
+        if p != row {
+            for j in 0..n {
+                r.swap((row, j), (p, j));
+            }
+        }
+        let piv = r[(row, col)];
+        for j in 0..n {
+            r[(row, j)] /= piv;
+        }
+        r[(row, col)] = 1.0;
+        for i in 0..m {
+            if i == row {
+                continue;
+            }
+            let f = r[(i, col)];
+            if f != 0.0 {
+                for j in 0..n {
+                    r[(i, j)] -= f * r[(row, j)];
+                }
+                r[(i, col)] = 0.0;
+            }
+        }
+        pivots.push(col);
+        row += 1;
+    }
+    // canonicalize negative zeros produced by eliminations
+    r.mapv_inplace(|x| if x == 0.0 { 0.0 } else { x });
+    (r, pivots)
+}
+
+#[pyfunction]
+fn rref<'py>(
+    py: Python<'py>,
+    a: PyReadonlyArray2<'py, f64>,
+) -> PyResult<(Bound<'py, PyArray2<f64>>, Vec<usize>)> {
+    let a = a.as_array();
+    let (r, pivots) = py.allow_threads(|| rref_impl(a));
+    Ok((r.to_pyarray(py), pivots))
+}
+
+/// Fused Gaussian factor + solve for square systems (partial pivoting).
+#[pyfunction]
+fn gauss_solve<'py>(
+    py: Python<'py>,
+    a: PyReadonlyArray2<'py, f64>,
+    b: PyReadonlyArray2<'py, f64>,
+) -> PyResult<Bound<'py, PyArray1<f64>>> {
+    let a = a.as_array();
+    let b = b.as_array();
+    let result = py.allow_threads(|| {
+        let n = a.nrows();
+        let tol = default_tol(&a);
+        let mut w = Array2::<f64>::zeros((n, n + 1));
+        for i in 0..n {
+            for j in 0..n {
+                w[(i, j)] = a[(i, j)];
+            }
+            w[(i, n)] = b[(i, 0)];
+        }
+        for k in 0..n {
+            let mut p = k;
+            let mut best = w[(k, k)].abs();
+            for i in (k + 1)..n {
+                if w[(i, k)].abs() > best {
+                    best = w[(i, k)].abs();
+                    p = i;
+                }
+            }
+            if best <= tol {
+                return Err("matrix is singular to working precision".to_string());
+            }
+            if p != k {
+                for j in 0..=n {
+                    w.swap((k, j), (p, j));
+                }
+            }
+            let piv = w[(k, k)];
+            for i in (k + 1)..n {
+                let f = w[(i, k)] / piv;
+                if f != 0.0 {
+                    for j in k..=n {
+                        w[(i, j)] -= f * w[(k, j)];
+                    }
+                }
+            }
+        }
+        let mut x = Array1::<f64>::zeros(n);
+        for i in (0..n).rev() {
+            let mut s = w[(i, n)];
+            for j in (i + 1)..n {
+                s -= w[(i, j)] * x[j];
+            }
+            x[i] = s / w[(i, i)];
+        }
+        Ok(x)
+    });
+    result
+        .map(|x| x.to_pyarray(py))
+        .map_err(PyValueError::new_err)
+}
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(ref_py, m)?)?;
+    m.add_function(wrap_pyfunction!(rref, m)?)?;
+    m.add_function(wrap_pyfunction!(gauss_solve, m)?)?;
+    Ok(())
+}

--- a/tests/test_elimination.py
+++ b/tests/test_elimination.py
@@ -1,0 +1,191 @@
+"""Tests for Gaussian elimination and row echelon forms (issue #85; §20.4).
+
+## Test: test_ref_structure
+- Goal: A.ref() returns a Mat in row echelon form: each row's leading
+        nonzero sits strictly right of the previous row's.
+- Source: issue #85 methods table ("upper triangular form via forward
+          elimination with partial pivoting").
+- Expected: staircase structure holds and row space is preserved (rank
+            of the stack equals rank of A).
+
+## Test: test_ref_pivot_none
+- Goal: pivot="none" performs classic unpivoted forward elimination
+        (pedagogical mode) and an unknown strategy is rejected.
+- Source: issue #85 pivoting strategy section.
+- Expected: known hand-computed REF for a matrix needing no swaps;
+            ValueError for pivot="bogus"; ValueError when a zero pivot
+            forces a swap that pivot="none" forbids.
+
+## Test: test_rref_known
+- Goal: A.rref() returns the canonical reduced row echelon form plus
+        pivot column indices.
+- Source: issue #85 methods table ("fully reduced form + list of pivot
+          column indices").
+- Expected: exact known RREF and pivots (0, 2) for a rank-2 matrix with
+            a dependent second column.
+
+## Test: test_rank
+- Goal: A.rank() counts pivot columns.
+- Source: issue #85 methods table.
+- Expected: 2 for the rank-2 matrix, n for the identity.
+
+## Test: test_nullspace
+- Goal: A.nullspace() returns a basis for the null space as Mat columns;
+        full-rank matrices give an empty (k, 0) basis.
+- Source: issue #85 methods table.
+- Expected: A @ N ≈ 0 with dim = k - rank(A); empty basis on identity.
+
+## Test: test_gaussian_eliminate
+- Goal: A.gaussian_eliminate(b) solves Ax = b by forward elimination +
+        back substitution; singular systems raise ValueError.
+- Source: issue #85 methods table.
+- Expected: solution matches np.linalg.solve; ValueError mentioning
+            "singular" for a singular A.
+
+## Test: test_gauss_jordan
+- Goal: A.gauss_jordan() returns the RREF of A; A.gauss_jordan(b)
+        returns the solution ColVec.
+- Source: issue #85 methods table ("if b provided, returns solution").
+- Expected: RREF equals A.rref()[0]; solution matches np.linalg.solve.
+
+## Test: test_augment
+- Goal: A.augment(b) builds the [A | b] augmented Mat and rejects row
+        mismatches.
+- Source: issue #85 methods table and augmented-systems note.
+- Expected: equals A | b; ShapeError on mismatched rows.
+
+## Test: test_ref_steps
+- Goal: A.ref_steps() yields (Mat, description) elimination steps ending
+        at the REF (pedagogical mode, Python-side by design).
+- Source: issue #85 step-by-step mode section.
+- Expected: every item is (Mat, str); final Mat equals A.ref().
+
+## Test: test_gaussian_square_guard
+- Goal: gaussian_eliminate rejects non-square systems with ShapeError.
+- Source: issue #85 (solving Ax = b is defined for square A here;
+          rectangular systems are out of the method's contract).
+- Expected: ShapeError on a 3x2 Mat.
+"""
+
+import numpy as np
+import pytest
+
+from nemopy import ColVec, Mat, ShapeError, _c, mat
+
+
+def _np(x):
+    return np.asarray(x)
+
+
+def _staircase_ok(r, tol=1e-12):
+    lead = -1
+    for i in range(r.shape[0]):
+        nz = np.flatnonzero(np.abs(r[i]) > tol)
+        if nz.size == 0:
+            lead = r.shape[1]
+            continue
+        if nz[0] <= lead:
+            return False
+        lead = nz[0]
+    return True
+
+
+def test_ref_structure(backend):
+    A = mat([2, -3, -2], [1, -1, 1], [-1, 2, 2])
+    R = A.ref()
+    assert isinstance(R, Mat)
+    assert _staircase_ok(_np(R))
+    stacked = np.vstack([_np(A), _np(R)])
+    assert np.linalg.matrix_rank(stacked) == np.linalg.matrix_rank(_np(A))
+
+
+def test_ref_pivot_none(backend):
+    A = mat([2, 1], [4, 3])  # rows [2,4],[1,3]: no swap needed
+    R = A.ref(pivot="none")
+    np.testing.assert_allclose(_np(R), [[2.0, 4.0], [0.0, 1.0]])
+    with pytest.raises(ValueError, match="pivot"):
+        A.ref(pivot="bogus")
+    with pytest.raises(ValueError, match="(?i)zero pivot"):
+        mat([0, 1], [1, 0]).ref(pivot="none")
+
+
+def test_rref_known(backend):
+    A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])  # col2 = 2*col1 -> rank 2
+    R, pivots = A.rref()
+    assert isinstance(R, Mat)
+    assert tuple(pivots) == (0, 2)
+    np.testing.assert_allclose(
+        _np(R), [[1.0, 2.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]],
+        atol=1e-12,
+    )
+
+
+def test_rank(backend):
+    A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])
+    assert A.rank() == 2
+    assert isinstance(A.rank(), int)
+    B = mat([1, 0], [0, 1])
+    assert B.rank() == 2
+
+
+def test_nullspace(backend):
+    A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])
+    N = A.nullspace()
+    assert isinstance(N, Mat)
+    assert N.shape == (3, 1)
+    np.testing.assert_allclose(_np(A) @ _np(N), np.zeros((3, 1)), atol=1e-10)
+    full = mat([1, 0], [0, 1]).nullspace()
+    assert full.shape == (2, 0)
+
+
+def test_gaussian_eliminate(backend):
+    A = mat([2, 1], [1, 3])
+    b = _c[5, 10]
+    x = A.gaussian_eliminate(b)
+    assert isinstance(x, ColVec)
+    np.testing.assert_allclose(
+        x.to_flat(), np.linalg.solve(_np(A), _np(b)).ravel(), atol=1e-12
+    )
+    singular = mat([1, 2], [2, 4])
+    with pytest.raises(ValueError, match="(?i)singular"):
+        singular.gaussian_eliminate(_c[1, 2])
+
+
+def test_gauss_jordan(backend):
+    A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])
+    R = A.gauss_jordan()
+    assert isinstance(R, Mat)
+    np.testing.assert_allclose(_np(R), _np(A.rref()[0]), atol=1e-12)
+    S = mat([2, 1], [1, 3])
+    b = _c[5, 10]
+    x = S.gauss_jordan(b)
+    assert isinstance(x, ColVec)
+    np.testing.assert_allclose(
+        x.to_flat(), np.linalg.solve(_np(S), _np(b)).ravel(), atol=1e-12
+    )
+
+
+def test_augment():
+    A = mat([1, 2], [3, 4])
+    b = _c[5, 6]
+    Ab = A.augment(b)
+    assert isinstance(Ab, Mat)
+    np.testing.assert_array_equal(_np(Ab), _np(A | b))
+    with pytest.raises(ShapeError):
+        A.augment(_c[1, 2, 3])
+
+
+def test_ref_steps():
+    A = mat([2, -3, -2], [1, -1, 1], [-1, 2, 2])
+    steps = list(A.ref_steps())
+    assert steps
+    for step, desc in steps:
+        assert isinstance(step, Mat)
+        assert isinstance(desc, str)
+    np.testing.assert_allclose(_np(steps[-1][0]), _np(A.ref()), atol=1e-12)
+
+
+def test_gaussian_square_guard():
+    rect = mat([1, 2], [3, 4], [5, 6])
+    with pytest.raises(ShapeError):
+        rect.gaussian_eliminate(_c[1, 2])


### PR DESCRIPTION
## Summary
Implements Gaussian elimination and row echelon form methods for the `Mat` class, addressing issue #85. Provides both production-grade Rust kernels (REF, RREF, fused Gaussian solve) and NumPy fallbacks, plus a pedagogical step-by-step elimination mode in Python.

## Key Changes

### New Module: `nemopy/_elimination.py`
- **`Mat.ref(pivot="partial")`** – Row echelon form via forward elimination with optional partial pivoting or unpivoted mode
- **`Mat.rref()`** – Reduced row echelon form returning (Mat, pivot_columns)
- **`Mat.rank()`** – Matrix rank as count of RREF pivot columns
- **`Mat.nullspace()`** – Null space basis vectors as Mat columns
- **`Mat.gaussian_eliminate(b)`** – Solve Ax = b by forward elimination + back substitution (square systems only)
- **`Mat.gauss_jordan(b=None)`** – Full Gauss-Jordan elimination; returns RREF if b is None, solution ColVec if b provided
- **`Mat.augment(b)`** – Build augmented matrix [A | b]
- **`Mat.ref_steps()`** – Pedagogical generator yielding (Mat, description) pairs for each elimination step

Includes tolerance-aware pivot detection and comprehensive error handling (singular matrices, shape mismatches, invalid pivot strategies).

### New Rust Module: `nemopy/_rust_core/src/linalg.rs`
- **`ref_impl()`** – REF kernel with partial/unpivoted pivoting modes
- **`rref_impl()`** – RREF kernel with pivot column tracking
- **`gauss_solve()`** – Fused Gaussian factorization + back substitution for square systems
- All kernels use tolerance-based pivot detection and allow threading

### Test Suite: `tests/test_elimination.py`
- 10 tests covering REF structure, RREF correctness, rank, nullspace, Gaussian elimination, Gauss-Jordan, augmentation, step-by-step mode, and shape guards
- Tests verify against NumPy reference implementations and known hand-computed results
- Includes error case validation (singular matrices, invalid pivoting strategies, shape mismatches)

### Integration
- Registered Rust functions in `_rust_core` module
- Imported `_elimination` module in `nemopy/__init__.py` to attach methods to `Mat`

## Implementation Notes
- Production path uses Rust kernels when available; NumPy fallback mirrors Rust semantics
- Step-by-step `ref_steps()` intentionally stays in Python for pedagogical clarity
- RREF primarily targets exact/small systems and teaching; large systems should use LU-backed solvers (numerical stability)
- Tolerance computed as `eps * max(shape) * scale` per issue #85 design
- Singular matrix detection uses tolerance-aware pivot checks; raises `ValueError` with clear messaging

https://claude.ai/code/session_01GgbBTWgc7jf9nHpwtfyn4p