### PR TITLE
docs(constructors): document _c scalars-only contract and empty ColVec idiom

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -59,6 +59,37 @@ immediately.
    ColVec([0.2857142857142857, 0.5714285714285714, 0.8571428571428571])
 
 
+Empty / placeholder column vector
+---------------------------------
+
+``_c`` builds a column vector from a flat sequence of scalars, so it has no
+empty form — ``_c[]`` is a Python ``SyntaxError``, and ``_c`` rejects
+non-scalar input such as lists. To create an empty placeholder column vector,
+wrap a ``(0, 1)`` array with ``ColVec`` directly. A ``(1, 0)`` array is a row,
+not a column, and is correctly rejected.
+
+.. doctest::
+
+   >>> # Empty placeholder — a valid (0, 1) column vector
+   >>> placeholder = ColVec(np.empty((0, 1)))
+   >>> placeholder
+   ColVec([])
+   >>> placeholder.shape
+   (0, 1)
+
+   >>> # A (1, 0) array is a row, not a column — rejected
+   >>> ColVec(np.empty((1, 0)))   # doctest: +IGNORE_EXCEPTION_DETAIL
+   Traceback (most recent call last):
+       ...
+   ShapeError: ...
+
+   >>> # _c takes scalars only — a nested list raises ValueError
+   >>> _c[[1, 2, 3]]   # doctest: +IGNORE_EXCEPTION_DETAIL
+   Traceback (most recent call last):
+       ...
+   ValueError: ...
+
+
 MATLAB-style matrix literals
 ------------------------------
 

--- a/nemopy/_constructors.py
+++ b/nemopy/_constructors.py
@@ -63,6 +63,15 @@ class _ColConstructor:
 
         ColVec(np.array([[1+2j], [3+4j]]))
 
+    ``_c`` accepts only a flat sequence of **scalars**. Strings, lists, tuples,
+    and arrays are rejected (use ``mat()`` for nested input). There is no empty
+    form — ``_c[]`` is invalid Python syntax. For an empty placeholder column
+    vector, wrap a ``(0, 1)`` array directly::
+
+        ColVec(np.empty((0, 1)))   # valid empty (0, 1) ColVec
+
+    A ``(1, 0)`` array is a row, not a column, and is rejected.
+
     Raises
     ------
     ValueError


### PR DESCRIPTION
## What

Docs-only resolution of #101 (Einstein-delegated, human-ruled **not a bug — documentation only, no behavior change**).

Documents:
1. The **scalars-only contract** of `_c`: it accepts only a flat sequence of scalars; strings, lists, tuples, and arrays are rejected (use `mat()`); there is no empty `_c[]` form because that is invalid Python syntax.
2. The supported **empty-placeholder idiom** `ColVec(np.empty((0, 1)))` → `ColVec([])` of shape `(0, 1)`, and that the `(1, 0)` shape (a row, not a column) is correctly rejected.

## DESIGN.md basis

- §3 — `_c` takes a flat sequence of scalars; nested input raises `ValueError`.
- §4.2 — `ColVec` requires shape `(n, 1)`; `(0, 1)` satisfies this, `(1, 0)` does not.

Verified empirically: `ColVec(np.empty((0,1)))` → `ColVec([])` shape `(0,1)`; `ColVec(np.empty((1,0)))` → `ShapeError`; `_c[[1,2,3]]` → `ValueError`.

## Changes

- `nemopy/_constructors.py` — `_c` (`_ColConstructor`) docstring: added a Notes paragraph (prose, matching the existing complex-vector note style).
- `docs/examples.rst` — new doctested section "Empty / placeholder column vector".

No code paths, signatures, or behavior changed (DESIGN.md §1). Did **not** touch `nemopy/_core.py` (Archimedes owns it for #105). Did not address the `_c[""]` string question (#102).

## Verification

- New doctests pass under `sphinx -b doctest`.
- `pytest tests/test_constructors.py tests/test_namespace.py` → 35 passed, 1 skipped.

## Pre-existing issues noted (out of scope, NOT touched per CLAUDE.md §3/§6.6)

- `_constructors.py` `_m["1; 2; 3"]` docstring example claims `Mat(3x1)` but actually returns `Mat(1x3)` (semicolons separate columns).
- `docs/examples.rst` has pre-existing doctest failures independent of this change (Column-extraction projection, OLS `beta`, `y_hat`) where documented numeric outputs do not match computed values. Confirmed present on the base branch without my changes.

Refs #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmYcaoKZUBrzgCGwPMmNuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmYcaoKZUBrzgCGwPMmNuQ)_