### PR TITLE
fix(tier-3): Tier-3 decomposition/elimination methods raise ImportError instead of NumPy/SciPy fallback

### DIFF
--- a/nemopy/_core.py
+++ b/nemopy/_core.py
@@ -995,3 +995,20 @@ def _load_rust_core():
 
 
 _RUST = _load_rust_core()
+
+
+def _require_rust(method):
+    """Return the loaded ``_rust_core`` extension or raise ``ImportError``.
+
+    Tier-3 features (DESIGN_APPENDICES.md §20.1/§20.4) have no NumPy
+    equivalent, so when the compiled extension is absent there is nothing
+    to fall back to. Raises a clear ``ImportError`` naming ``method`` and
+    pointing at the build step instead of computing a substitute answer.
+    """
+    if _RUST is None:
+        raise ImportError(
+            f"Mat.{method}() requires the compiled nemopy._rust_core "
+            f"extension, which is not available. Build it with "
+            f"`maturin develop` to enable this Tier-3 feature."
+        )
+    return _RUST

--- a/nemopy/_decompositions.py
+++ b/nemopy/_decompositions.py
@@ -193,26 +193,6 @@ DiagonalizeResult = namedtuple("DiagonalizeResult", ["P", "D"])
 JordanResult = namedtuple("JordanResult", ["J", "P"])
 
 
-def _ldu_fallback(a):
-    n = a.shape[0]
-    scale = max(1.0, float(np.abs(a).max()))
-    u = a.copy()
-    low = np.eye(n)
-    for k in range(n):
-        piv = u[k, k]
-        if abs(piv) < 1e-12 * scale:
-            raise ValueError(
-                f"LDU requires nonzero pivots without row exchanges; zero "
-                f"pivot at position {k}. Use lu() for a pivoted factorization."
-            )
-        f = u[k + 1:, k] / piv
-        low[k + 1:, k] = f
-        u[k + 1:, k:] -= np.outer(f, u[k, k:])
-    d = np.diag(u).copy()
-    u = u / d[:, None]
-    return low, d, u
-
-
 def _mat_ldu(self):
     """LDU factorization ``A = L @ D @ U`` without row exchanges.
 
@@ -225,13 +205,13 @@ def _mat_ldu(self):
     ValueError
         If elimination hits a zero pivot (pivoting would be required);
         use :meth:`lu` instead.
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
     a = _require_square(self, "ldu")
-    rust = _core._RUST
-    if rust is not None:
-        low, d, u = rust.ldu(a)
-    else:
-        low, d, u = _ldu_fallback(a)
+    rust = _core._require_rust("ldu")
+    low, d, u = rust.ldu(a)
     return LDUResult(Mat(np.asarray(low)), Mat(np.diag(np.asarray(d))),
                      Mat(np.asarray(u)))
 
@@ -248,7 +228,11 @@ def _mat_qdr(self):
     ValueError
         If the QR ``R`` factor has a zero diagonal entry (rank
         deficiency), so the unit-diagonal rescaling does not exist.
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
+    _core._require_rust("qdr")
     q, r = _mat_qr(self)
     r = np.asarray(r)
     d = np.diag(r).copy()
@@ -262,17 +246,21 @@ def _mat_qdr(self):
 def _mat_schur(self):
     """Real Schur decomposition ``A = Z @ T @ Z.T``.
 
-    LAPACK-delegated via SciPy on both paths pending a ``_rust_core``
-    Schur kernel (issue #84 interim).
+    A Tier-3 feature (§20.1/§20.4) that requires the ``_rust_core``
+    extension; the computation is LAPACK-delegated via SciPy pending a
+    ``_rust_core`` Schur kernel (issue #84 interim).
 
     Raises
     ------
     ShapeError
         If the matrix is not square.
     ImportError
-        If SciPy is not installed.
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback), or if SciPy is not installed on the
+        interim delegated path.
     """
     a = _require_square(self, "schur")
+    _core._require_rust("schur")
     try:
         from scipy.linalg import schur as _scipy_schur
     except ImportError as exc:
@@ -288,9 +276,15 @@ def _mat_polar(self):
     """Left polar decomposition ``A = U @ P``.
 
     ``U`` has orthonormal columns and ``P`` is symmetric positive
-    semidefinite. Derived from the thin SVD, so it uses the Rust SVD
-    kernel when available.
+    semidefinite. Derived from the thin SVD via the Rust kernel.
+
+    Raises
+    ------
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
+    _core._require_rust("polar")
     u, s, vt = _mat_svd(self)
     u, s, vt = np.asarray(u), np.asarray(s).ravel(), np.asarray(vt)
     return PolarResult(Mat(u @ vt), Mat(vt.T @ np.diag(s) @ vt))
@@ -311,8 +305,12 @@ def _mat_diagonalize(self):
         If the matrix is not square.
     ValueError
         If the matrix is not diagonalizable (defective eigenbasis).
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
     a = _require_square(self, "diagonalize")
+    _core._require_rust("diagonalize")
     n = a.shape[0]
     result = _mat_eig(self)
     vecs = np.asarray(result.vectors)
@@ -350,8 +348,12 @@ def _mat_jordan(self):
         If the matrix is not square.
     ValueError
         If a complete generalized eigenbasis cannot be assembled.
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
     a = _require_square(self, "jordan")
+    _core._require_rust("jordan")
     n = a.shape[0]
     scale = max(1.0, float(np.abs(a).max()))
     tol = 1e-8 * scale

--- a/nemopy/_elimination.py
+++ b/nemopy/_elimination.py
@@ -1,11 +1,13 @@
 """Gaussian elimination and row echelon forms as Mat methods (issue #85).
 
-The production path runs in ``_rust_core.linalg`` (REF/RREF, fused
-Gaussian solve); the NumPy fallback mirrors its semantics per §20.1. The
-step-by-step ``ref_steps()`` pedagogy mode stays in Python by design.
-RREF is primarily valuable for exact/small systems and teaching; for
-large systems prefer the LU-backed solvers (numerical-stability note in
-issue #85).
+These are Tier-3, Rust-primary features (DESIGN_APPENDICES.md
+§20.1/§20.4): they have no NumPy equivalent, so the production path runs
+in ``_rust_core.linalg`` (REF/RREF, fused Gaussian solve) and a clear
+``ImportError`` is raised when the extension is absent — there is no
+NumPy fallback. The step-by-step ``ref_steps()`` pedagogy mode stays in
+Python by design. RREF is primarily valuable for exact/small systems and
+teaching; for large systems prefer the LU-backed solvers
+(numerical-stability note in issue #85).
 """
 
 import numpy as np
@@ -17,60 +19,6 @@ from nemopy._core import ColVec, Mat, ShapeError
 def _default_tol(a):
     scale = max(1.0, float(np.abs(a).max())) if a.size else 1.0
     return np.finfo(float).eps * max(a.shape) * scale
-
-
-def _ref_fallback(a, partial):
-    m, n = a.shape
-    r = a.copy()
-    tol = _default_tol(a)
-    row = 0
-    for col in range(n):
-        if row >= m:
-            break
-        if partial:
-            p = row + int(np.argmax(np.abs(r[row:, col])))
-        else:
-            p = row
-        if abs(r[p, col]) <= tol:
-            if not partial and np.any(np.abs(r[row + 1:, col]) > tol):
-                raise ValueError(
-                    f'zero pivot in column {col} requires a row exchange; '
-                    f'use pivot="partial"'
-                )
-            continue
-        if p != row:
-            r[[row, p], :] = r[[p, row], :]
-        f = r[row + 1:, col] / r[row, col]
-        r[row + 1:, col:] -= np.outer(f, r[row, col:])
-        r[row + 1:, col] = 0.0
-        row += 1
-    return r
-
-
-def _rref_fallback(a):
-    m, n = a.shape
-    r = a.copy()
-    tol = _default_tol(a)
-    pivots = []
-    row = 0
-    for col in range(n):
-        if row >= m:
-            break
-        p = row + int(np.argmax(np.abs(r[row:, col])))
-        if abs(r[p, col]) <= tol:
-            continue
-        if p != row:
-            r[[row, p], :] = r[[p, row], :]
-        r[row, :] /= r[row, col]
-        r[row, col] = 1.0
-        others = [i for i in range(m) if i != row]
-        f = r[others, col]
-        r[others, :] -= np.outer(f, r[row, :])
-        r[others, col] = 0.0
-        pivots.append(col)
-        row += 1
-    r[r == 0.0] = 0.0
-    return r, pivots
 
 
 def _mat_ref(self, pivot="partial"):
@@ -93,10 +41,8 @@ def _mat_ref(self, pivot="partial"):
             f'pivot must be "partial" or "none", got {pivot!r}'
         )
     a = np.asarray(self)
-    rust = _core._RUST
-    if rust is not None:
-        return Mat(rust.ref_(a, pivot == "partial"))
-    return Mat(_ref_fallback(a, pivot == "partial"))
+    rust = _core._require_rust("ref")
+    return Mat(rust.ref_(a, pivot == "partial"))
 
 
 def _mat_rref(self):
@@ -108,16 +54,21 @@ def _mat_rref(self):
         The canonical RREF and the pivot column indices.
     """
     a = np.asarray(self)
-    rust = _core._RUST
-    if rust is not None:
-        r, pivots = rust.rref(a)
-    else:
-        r, pivots = _rref_fallback(a)
+    rust = _core._require_rust("rref")
+    r, pivots = rust.rref(a)
     return Mat(np.asarray(r)), tuple(int(p) for p in pivots)
 
 
 def _mat_rank(self):
-    """Rank as the number of RREF pivot columns (tolerance-aware)."""
+    """Rank as the number of RREF pivot columns (tolerance-aware).
+
+    Raises
+    ------
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
+    """
+    _core._require_rust("rank")
     return len(_mat_rref(self)[1])
 
 
@@ -125,7 +76,14 @@ def _mat_nullspace(self):
     """Null space basis vectors as Mat columns (from the RREF).
 
     A full-rank matrix returns an empty ``(k, 0)`` Mat.
+
+    Raises
+    ------
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
+    _core._require_rust("nullspace")
     k = self.shape[1]
     r, pivots = _mat_rref(self)
     r = np.asarray(r)
@@ -159,6 +117,9 @@ def _mat_gaussian_eliminate(self, b):
         If A is not square or b has the wrong shape.
     ValueError
         If A is singular to working precision.
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
     if self.shape[0] != self.shape[1]:
         raise ShapeError(
@@ -167,25 +128,9 @@ def _mat_gaussian_eliminate(self, b):
         )
     a = np.asarray(self)
     b = _check_rhs(self, b, "gaussian_eliminate")
-    rust = _core._RUST
-    if rust is not None:
-        x = rust.gauss_solve(a, b)
-        return ColVec(np.asarray(x).reshape(-1, 1))
-    w = np.hstack([a, b]).astype(float)
-    n = a.shape[0]
-    tol = _default_tol(a)
-    for k in range(n):
-        p = k + int(np.argmax(np.abs(w[k:, k])))
-        if abs(w[p, k]) <= tol:
-            raise ValueError("matrix is singular to working precision")
-        if p != k:
-            w[[k, p], :] = w[[p, k], :]
-        f = w[k + 1:, k] / w[k, k]
-        w[k + 1:, k:] -= np.outer(f, w[k, k:])
-    x = np.zeros(n)
-    for i in range(n - 1, -1, -1):
-        x[i] = (w[i, n] - w[i, i + 1:n] @ x[i + 1:]) / w[i, i]
-    return ColVec(x.reshape(-1, 1))
+    rust = _core._require_rust("gaussian_eliminate")
+    x = rust.gauss_solve(a, b)
+    return ColVec(np.asarray(x).reshape(-1, 1))
 
 
 def _mat_gauss_jordan(self, b=None):
@@ -201,7 +146,11 @@ def _mat_gauss_jordan(self, b=None):
         With ``b``: if A is not square or b has the wrong shape.
     ValueError
         With ``b``: if A is singular to working precision.
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
+    _core._require_rust("gauss_jordan")
     if b is None:
         return _mat_rref(self)[0]
     if self.shape[0] != self.shape[1]:
@@ -225,6 +174,9 @@ def _mat_augment(self, b):
     ------
     ShapeError
         If b's row count differs from A's.
+    ImportError
+        If the ``_rust_core`` extension is not available (Tier-3 feature
+        with no NumPy fallback; §20.1/§20.4).
     """
     b = np.asarray(b, dtype=float)
     if b.ndim == 1:
@@ -234,6 +186,7 @@ def _mat_augment(self, b):
             f"augment() requires equal row counts, got {self.shape} "
             f"and {b.shape}."
         )
+    _core._require_rust("augment")
     return Mat(np.hstack([np.asarray(self), b]))
 
 

--- a/tests/test_decompositions_advanced.py
+++ b/tests/test_decompositions_advanced.py
@@ -49,19 +49,47 @@
 - Source: issue #84 design principles ("Raise ShapeError for non-square
           matrices where squareness is required").
 - Expected: ShapeError for ldu/schur/jordan/diagonalize on a 3x2 Mat.
+
+## Test: test_tier3_requires_rust
+- Goal: every Tier-3 advanced decomposition (ldu, qdr, schur, polar,
+        diagonalize, jordan) raises a clear ImportError naming the method
+        when _rust_core is absent, instead of assembling a NumPy/SciPy
+        answer from Tier-2 primitives.
+- Source: DESIGN_APPENDICES.md §20.1 (Rust-primary: no Python fallback)
+          and §20.4 (these methods are tier "3 — Rust-primary"); issue
+          #105.
+- Expected: ImportError matching the method name with _core._RUST forced
+            to None.
 """
 
 import numpy as np
 import pytest
 
-from nemopy import Mat, ShapeError, mat
+from nemopy import Mat, ShapeError, _core, mat
+
+# Advanced decompositions (issue #84) are Rust-primary per
+# DESIGN_APPENDICES.md §20.1/§20.4: no NumPy/SciPy fallback exists, so the
+# production computation only runs when the compiled extension is present.
+# Correctness tests are gated on that; ImportError-when-absent is asserted
+# separately in test_tier3_requires_rust.
+requires_rust = pytest.mark.skipif(
+    _core._RUST is None,
+    reason="_rust_core extension not built (Tier-3 requires Rust)",
+)
+
+# Public Tier-3 advanced-decomposition methods (#84), asserted to raise
+# ImportError when _rust_core is absent.
+_TIER3_METHODS = (
+    "ldu", "qdr", "schur", "polar", "diagonalize", "jordan",
+)
 
 
 def _np(x):
     return np.asarray(x)
 
 
-def test_ldu(backend):
+@requires_rust
+def test_ldu():
     A = mat([4, 2], [2, 5])
     L, D, U = A.ldu()
     np.testing.assert_allclose(_np(L) @ _np(D) @ _np(U), _np(A), atol=1e-10)
@@ -72,7 +100,8 @@ def test_ldu(backend):
         mat([0, 1], [1, 0]).ldu()
 
 
-def test_qdr(backend):
+@requires_rust
+def test_qdr():
     A = mat([3, 4, 0], [-4, 3, 1], [1, 0, 2])
     Q, D, R = A.qdr()
     np.testing.assert_allclose(_np(Q) @ _np(D) @ _np(R), _np(A), atol=1e-10)
@@ -81,6 +110,7 @@ def test_qdr(backend):
     np.testing.assert_allclose(np.diag(_np(R)), np.ones(3), atol=1e-12)
 
 
+@requires_rust
 def test_schur():
     pytest.importorskip("scipy")
     A = mat([4, 1, 0], [2, 3, 1], [0, 1, 2])
@@ -90,7 +120,8 @@ def test_schur():
     np.testing.assert_allclose(_np(Z).T @ _np(Z), np.eye(3), atol=1e-10)
 
 
-def test_polar(backend):
+@requires_rust
+def test_polar():
     A = mat([3, 1, 0], [1, 2, 1])  # tall (3, 2)
     U, P = A.polar()
     assert isinstance(U, Mat) and isinstance(P, Mat)
@@ -100,6 +131,7 @@ def test_polar(backend):
     assert np.linalg.eigvalsh(_np(P)).min() >= -1e-10
 
 
+@requires_rust
 def test_diagonalize():
     A = mat([2, 0], [1, 3])
     P, D = A.diagonalize()
@@ -112,6 +144,7 @@ def test_diagonalize():
         defective.diagonalize()
 
 
+@requires_rust
 def test_jordan():
     A = mat([2, 0], [1, 3])  # diagonalizable
     J, P = A.jordan()
@@ -133,3 +166,11 @@ def test_advanced_square_guards():
     for method in ("ldu", "schur", "jordan", "diagonalize"):
         with pytest.raises(ShapeError):
             getattr(rect, method)()
+
+
+@pytest.mark.parametrize("method", _TIER3_METHODS)
+def test_tier3_requires_rust(method, monkeypatch):
+    monkeypatch.setattr(_core, "_RUST", None)
+    A = mat([4, 2], [2, 5])
+    with pytest.raises(ImportError, match=method):
+        getattr(A, method)()

--- a/tests/test_elimination.py
+++ b/tests/test_elimination.py
@@ -65,12 +65,44 @@
 - Source: issue #85 (solving Ax = b is defined for square A here;
           rectangular systems are out of the method's contract).
 - Expected: ShapeError on a 3x2 Mat.
+
+## Test: test_tier3_requires_rust
+- Goal: every Tier-3 elimination method (ref, rref, rank, nullspace,
+        gaussian_eliminate, gauss_jordan, augment) raises a clear
+        ImportError naming the method when _rust_core is absent, rather
+        than computing a NumPy/SciPy answer.
+- Source: DESIGN_APPENDICES.md §20.1 (Rust-primary: no Python fallback)
+          and §20.4 (these methods are tier "3 — Rust-primary"); issue
+          #105.
+- Expected: ImportError matching the method name with _core._RUST forced
+            to None.
 """
 
 import numpy as np
 import pytest
 
-from nemopy import ColVec, Mat, ShapeError, _c, mat
+from nemopy import ColVec, Mat, ShapeError, _c, _core, mat
+
+# Tier-3 elimination (issue #85) is Rust-primary per DESIGN_APPENDICES.md
+# §20.1/§20.4: there is no NumPy fallback, so the production computation
+# only runs when the compiled extension is present. Correctness tests are
+# gated on that; ImportError-when-absent is asserted separately.
+requires_rust = pytest.mark.skipif(
+    _core._RUST is None,
+    reason="_rust_core extension not built (Tier-3 requires Rust)",
+)
+
+# Public Tier-3 elimination methods (#85) and a representative call for
+# each, used to assert the ImportError contract when _rust_core is absent.
+_TIER3_CALLS = {
+    "ref": (),
+    "rref": (),
+    "rank": (),
+    "nullspace": (),
+    "gaussian_eliminate": (_c[5, 10],),
+    "gauss_jordan": (_c[5, 10],),
+    "augment": (_c[5, 10],),
+}
 
 
 def _np(x):
@@ -90,7 +122,8 @@ def _staircase_ok(r, tol=1e-12):
     return True
 
 
-def test_ref_structure(backend):
+@requires_rust
+def test_ref_structure():
     A = mat([2, -3, -2], [1, -1, 1], [-1, 2, 2])
     R = A.ref()
     assert isinstance(R, Mat)
@@ -99,7 +132,8 @@ def test_ref_structure(backend):
     assert np.linalg.matrix_rank(stacked) == np.linalg.matrix_rank(_np(A))
 
 
-def test_ref_pivot_none(backend):
+@requires_rust
+def test_ref_pivot_none():
     A = mat([2, 1], [4, 3])  # rows [2,4],[1,3]: no swap needed
     R = A.ref(pivot="none")
     np.testing.assert_allclose(_np(R), [[2.0, 4.0], [0.0, 1.0]])
@@ -109,7 +143,8 @@ def test_ref_pivot_none(backend):
         mat([0, 1], [1, 0]).ref(pivot="none")
 
 
-def test_rref_known(backend):
+@requires_rust
+def test_rref_known():
     A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])  # col2 = 2*col1 -> rank 2
     R, pivots = A.rref()
     assert isinstance(R, Mat)
@@ -120,7 +155,8 @@ def test_rref_known(backend):
     )
 
 
-def test_rank(backend):
+@requires_rust
+def test_rank():
     A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])
     assert A.rank() == 2
     assert isinstance(A.rank(), int)
@@ -128,7 +164,8 @@ def test_rank(backend):
     assert B.rank() == 2
 
 
-def test_nullspace(backend):
+@requires_rust
+def test_nullspace():
     A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])
     N = A.nullspace()
     assert isinstance(N, Mat)
@@ -138,7 +175,8 @@ def test_nullspace(backend):
     assert full.shape == (2, 0)
 
 
-def test_gaussian_eliminate(backend):
+@requires_rust
+def test_gaussian_eliminate():
     A = mat([2, 1], [1, 3])
     b = _c[5, 10]
     x = A.gaussian_eliminate(b)
@@ -151,7 +189,8 @@ def test_gaussian_eliminate(backend):
         singular.gaussian_eliminate(_c[1, 2])
 
 
-def test_gauss_jordan(backend):
+@requires_rust
+def test_gauss_jordan():
     A = mat([1, 2, 3], [2, 4, 6], [1, 1, 1])
     R = A.gauss_jordan()
     assert isinstance(R, Mat)
@@ -167,12 +206,14 @@ def test_gauss_jordan(backend):
 
 def test_augment():
     A = mat([1, 2], [3, 4])
+    with pytest.raises(ShapeError):
+        A.augment(_c[1, 2, 3])
+    if _core._RUST is None:
+        return
     b = _c[5, 6]
     Ab = A.augment(b)
     assert isinstance(Ab, Mat)
     np.testing.assert_array_equal(_np(Ab), _np(A | b))
-    with pytest.raises(ShapeError):
-        A.augment(_c[1, 2, 3])
 
 
 def test_ref_steps():
@@ -182,10 +223,19 @@ def test_ref_steps():
     for step, desc in steps:
         assert isinstance(step, Mat)
         assert isinstance(desc, str)
-    np.testing.assert_allclose(_np(steps[-1][0]), _np(A.ref()), atol=1e-12)
+    if _core._RUST is not None:
+        np.testing.assert_allclose(_np(steps[-1][0]), _np(A.ref()), atol=1e-12)
 
 
 def test_gaussian_square_guard():
     rect = mat([1, 2], [3, 4], [5, 6])
     with pytest.raises(ShapeError):
         rect.gaussian_eliminate(_c[1, 2])
+
+
+@pytest.mark.parametrize("method", sorted(_TIER3_CALLS))
+def test_tier3_requires_rust(method, monkeypatch):
+    monkeypatch.setattr(_core, "_RUST", None)
+    A = mat([2, 1], [1, 3])
+    with pytest.raises(ImportError, match=method):
+        getattr(A, method)(*_TIER3_CALLS[method])


### PR DESCRIPTION
Closes the spec violation in #105. (Branch is this session's designated remote branch `claude/tier3-importerror-xnnawj`, not the `archimedes/105-…` convention — the remote harness pins the branch name.)

## What & why

Tier-3 decomposition (#84) and elimination (#85) methods had no NumPy equivalent yet silently computed a pure-NumPy/SciPy substitute when `_rust_core` was absent. `DESIGN_APPENDICES.md` **§20.1(3)** (Rust-primary: "features that do not exist in NumPy … raise a clear `ImportError` … **No Python fallback is required**") and **§20.4** (all of #84/#85 are tier "3 — Rust-primary") require a clear `ImportError` instead — there is nothing to defer to.

## Changes

- **`nemopy/_core.py`** — new shared helper `_require_rust(method)`: returns the loaded extension, or raises `ImportError` naming the method and pointing at `maturin develop`.
- **`nemopy/_decompositions.py`** — route `ldu, qdr, schur, polar, diagonalize, jordan` through `_require_rust`; drop the now-unused `_ldu_fallback`. Composed methods (`qdr`←qr, `polar`←svd, `diagonalize`/`jordan`←eig) are gated **before** delegating to their Tier-2 primitive, so no NumPy answer is ever assembled.
- **`nemopy/_elimination.py`** — route `ref, rref, rank, nullspace, gaussian_eliminate, gauss_jordan, augment` through `_require_rust`; drop the now-unused `_ref_fallback`/`_rref_fallback` and the NumPy back-substitution block. `rank`/`nullspace`/`gauss_jordan` are gated directly so the error names the called method, not `rref`.
- Existing **shape/pivot guards run before** the Rust check, so the `ShapeError`/`ValueError` contracts for bad input are unchanged (e.g. `gaussian_eliminate` on a non-square matrix still raises `ShapeError`).

## Tests

- New `test_tier3_requires_rust` in both suites asserts each of the **13** methods raises `ImportError` (matching the method name) with `_core._RUST` forced to `None` — red before the fix, green after.
- The existing Tier-3 correctness tests had **no NumPy fallback left to exercise**, so (per maintainer authorization) they were **rewritten in place**: gated on the Rust path being present (skip when the extension isn't built), with the rust-absent `ShapeError` guards still running unconditionally. `ref_steps` (pure-Python pedagogy, out of scope) keeps its structural assertions and only gates its `.ref()` comparison.

## Decisions (maintainer-confirmed; §20.4 is the authority)

1. **All 13 → ImportError**, including `rank`/`augment`/`gaussian_eliminate`/`gauss_jordan` that have a direct NumPy equivalent — they are part of the Rust #85 domain (nemopy's `rank` counts RREF pivots, not a `matrix_rank` wrapper), not NumPy-wrapping features.
2. **Composed methods → ImportError** (don't assemble a NumPy answer from Tier-2 primitives).

## Out of scope / untouched

- Tier-2 decompositions `svd/qr/lu/cholesky/eig/eigh` (#76) and #77 stats keep their NumPy fallbacks — verified unchanged.
- No Rust kernels or public signatures changed (`DESIGN.md` §1).

## Pre-existing blocker (not addressed here, per CLAUDE.md §3)

4 failures in `tests/numpy_compat/test_multiarray.py` (`TestStats::test_keepdims/test_out/test_dtype_from_dtype`, `TestVdot::test_basic`) reproduce on `main` with this branch's source changes stashed — NumPy-2.4 vendored-compat drift, unrelated to #105. `tests/test_compat_matplotlib.py` fails to collect in this env because `matplotlib` isn't installed (optional dep). The two suites in scope pass: **17 passed, 13 skipped** (skips are the Rust-gated correctness tests, extension not built here).

## Process

- **#84 and #85 stay OPEN** until this merges.
- **Newton gates this PR** — not mergeable until his review comments "approved."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft5QDEJ5oxA5wvdurCxkWg)_