### PR TITLE
feat(ops): Phase 2 core fused arithmetic — fused_add/mul/div (#109)

### DIFF
--- a/nemopy/_operators.py
+++ b/nemopy/_operators.py
@@ -44,6 +44,14 @@ def _check_shapes(a, b, op_name):
 
 def __mul__(self, other):
     other = _coerce_1d(self, other)
+    rust = _core._RUST
+    if (
+        rust is not None
+        and isinstance(other, _VecBase)
+        and self.dtype == np.float64
+        and other.dtype == np.float64
+    ):
+        return _core._apply_type_rules(rust.fused_mul(self, other))
     _check_shapes(self, other, "*")
     return super(_VecBase, self).__mul__(other)
 
@@ -56,6 +64,14 @@ def __rmul__(self, other):
 
 def __add__(self, other):
     other = _coerce_1d(self, other)
+    rust = _core._RUST
+    if (
+        rust is not None
+        and isinstance(other, _VecBase)
+        and self.dtype == np.float64
+        and other.dtype == np.float64
+    ):
+        return _core._apply_type_rules(rust.fused_add(self, other))
     _check_shapes(self, other, "+")
     return super(_VecBase, self).__add__(other)
 
@@ -88,6 +104,14 @@ def __rsub__(self, other):
 
 def __truediv__(self, other):
     other = _coerce_1d(self, other)
+    rust = _core._RUST
+    if (
+        rust is not None
+        and isinstance(other, _VecBase)
+        and self.dtype == np.float64
+        and other.dtype == np.float64
+    ):
+        return _core._apply_type_rules(rust.fused_div(self, other))
     _check_shapes(self, other, "/")
     return super(_VecBase, self).__truediv__(other)
 

--- a/nemopy/_rust_core/src/ops.rs
+++ b/nemopy/_rust_core/src/ops.rs
@@ -51,8 +51,89 @@ fn fused_sub<'py>(
     Ok(out.to_pyarray(py))
 }
 
+/// Fused shape guard + elementwise addition (issue #109 Phase 2).
+#[pyfunction]
+fn fused_add<'py>(
+    py: Python<'py>,
+    a: PyReadonlyArray2<'py, f64>,
+    b: PyReadonlyArray2<'py, f64>,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let a = a.as_array();
+    let b = b.as_array();
+    if a.shape() != b.shape() {
+        return Err(shape_error(
+            py,
+            format!(
+                "Element-wise '+' requires identical shapes, got ({}, {}) and ({}, {}). \
+                 If broadcasting is intended, use np.multiply / np.add directly.",
+                a.shape()[0],
+                a.shape()[1],
+                b.shape()[0],
+                b.shape()[1]
+            ),
+        ));
+    }
+    let out = py.allow_threads(|| &a + &b);
+    Ok(out.to_pyarray(py))
+}
+
+/// Fused shape guard + elementwise multiplication (issue #109 Phase 2).
+#[pyfunction]
+fn fused_mul<'py>(
+    py: Python<'py>,
+    a: PyReadonlyArray2<'py, f64>,
+    b: PyReadonlyArray2<'py, f64>,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let a = a.as_array();
+    let b = b.as_array();
+    if a.shape() != b.shape() {
+        return Err(shape_error(
+            py,
+            format!(
+                "Element-wise '*' requires identical shapes, got ({}, {}) and ({}, {}). \
+                 If broadcasting is intended, use np.multiply / np.add directly.",
+                a.shape()[0],
+                a.shape()[1],
+                b.shape()[0],
+                b.shape()[1]
+            ),
+        ));
+    }
+    let out = py.allow_threads(|| &a * &b);
+    Ok(out.to_pyarray(py))
+}
+
+/// Fused shape guard + elementwise division (issue #109 Phase 2).
+#[pyfunction]
+fn fused_div<'py>(
+    py: Python<'py>,
+    a: PyReadonlyArray2<'py, f64>,
+    b: PyReadonlyArray2<'py, f64>,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let a = a.as_array();
+    let b = b.as_array();
+    if a.shape() != b.shape() {
+        return Err(shape_error(
+            py,
+            format!(
+                "Element-wise '/' requires identical shapes, got ({}, {}) and ({}, {}). \
+                 If broadcasting is intended, use np.multiply / np.add directly.",
+                a.shape()[0],
+                a.shape()[1],
+                b.shape()[0],
+                b.shape()[1]
+            ),
+        ));
+    }
+    let out = py.allow_threads(|| &a / &b);
+    Ok(out.to_pyarray(py))
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(register_shape_error, m)?)?;
     m.add_function(wrap_pyfunction!(fused_sub, m)?)?;
+    m.add_function(wrap_pyfunction!(fused_add, m)?)?;
+    m.add_function(wrap_pyfunction!(fused_mul, m)?)?;
+    m.add_function(wrap_pyfunction!(fused_div, m)?)?;
     Ok(())
 }

--- a/tests/test_rust_core.py
+++ b/tests/test_rust_core.py
@@ -35,7 +35,31 @@
 - Source: DESIGN_APPENDICES.md §20.1 fallback scope (owner amendment).
 - Expected: same values/types via the pure-NumPy path, and the same
             ShapeError on mismatched shapes.
+
+## Test: test_fused_arith_parity
+- Goal: Verify each forward operator (+, *, /) dispatches through its Phase 2
+        Rust kernel and the Rust-path result matches the pure-NumPy fallback
+        in both value and nemopy result type. A spy on the kernel proves the
+        dispatch actually routes to Rust (otherwise the value parity is
+        vacuous); computing the reference with the extension forced absent
+        exercises the retained Tier-2 fallback.
+- Source: issue #109 Phase 2 (fused_add/mul/div); DESIGN_APPENDICES.md
+          §20.1 (results agree across paths; Tier-2 fallback retained),
+          §20.3 (type persistence), §20.5 (Phase 2 hot-path replacement).
+- Expected: kernel invoked; ColVec op ColVec → ColVec, Mat op Mat → Mat;
+            Rust-path values equal the forced-fallback values.
+
+## Test: test_fused_arith_shape_error_message
+- Goal: Verify each Phase 2 kernel fuses the shape guard and raises
+        ShapeError with the same per-operator message contract as fused_sub.
+- Source: DESIGN.md §7 shape-guarded arithmetic (message text in
+          nemopy._operators._check_shapes); issue #109 (kernels fuse the
+          guard, so they must preserve guard semantics).
+- Expected: ShapeError whose message starts with "Element-wise '<op>'
+            requires identical shapes".
 """
+
+import operator
 
 import numpy as np
 import pytest
@@ -85,3 +109,52 @@ def test_sub_fallback_without_extension(monkeypatch):
     assert d.to_list() == [4.0, 5.0, 6.0]
     with pytest.raises(ShapeError, match=r"identical shapes"):
         mat([1, 2], [3, 4]) - mat([1, 2, 3], [4, 5, 6])
+
+
+@requires_rust
+@pytest.mark.parametrize(
+    "op, kernel",
+    [
+        (operator.add, "fused_add"),
+        (operator.mul, "fused_mul"),
+        (operator.truediv, "fused_div"),
+    ],
+)
+def test_fused_arith_parity(op, kernel, monkeypatch):
+    col_a, col_b = _c[5, 7, 9], _c[1, 2, 3]
+    mat_a, mat_b = mat([5, 7], [9, 11]), mat([1, 2], [3, 4])
+
+    with monkeypatch.context() as m:
+        m.setattr(_core, "_RUST", None)
+        numpy_col, numpy_mat = op(col_a, col_b), op(mat_a, mat_b)
+
+    invoked = {}
+    original = getattr(_core._RUST, kernel)
+
+    def spy(a, b, _orig=original):
+        invoked["called"] = True
+        return _orig(a, b)
+
+    monkeypatch.setattr(_core._RUST, kernel, spy)
+    rust_col, rust_mat = op(col_a, col_b), op(mat_a, mat_b)
+
+    assert invoked.get("called")
+    assert isinstance(rust_col, ColVec) and isinstance(numpy_col, ColVec)
+    assert isinstance(rust_mat, Mat) and isinstance(numpy_mat, Mat)
+    np.testing.assert_array_equal(np.asarray(rust_col), np.asarray(numpy_col))
+    np.testing.assert_array_equal(np.asarray(rust_mat), np.asarray(numpy_mat))
+
+
+@requires_rust
+@pytest.mark.parametrize(
+    "kernel, symbol",
+    [("fused_add", "+"), ("fused_mul", "*"), ("fused_div", "/")],
+)
+def test_fused_arith_shape_error_message(kernel, symbol):
+    a = np.asarray(_c[1, 2, 3])
+    b = np.asarray(_c[1, 2])
+    with pytest.raises(
+        ShapeError,
+        match=rf"Element-wise '\{symbol}' requires identical shapes",
+    ):
+        getattr(_core._RUST, kernel)(a, b)


### PR DESCRIPTION
## What

Completes **Phase 2** of the Rust core (`DESIGN_APPENDICES.md` §20.5 — "hot-path replacement of the top profiled bottlenecks"), which had been skipped. Ports the remaining core element-wise arithmetic to Rust so `+`, `*`, `/` join `-` on the fused fast path.

Closes #109.

## Changes (files: `ops.rs` + `_operators.py` only)

- **`nemopy/_rust_core/src/ops.rs`** — add `fused_add`, `fused_mul`, `fused_div`, each an exact mirror of the existing `fused_sub`: identical shape-guard with the same `ShapeError` message format (only the operator symbol differs), same `py.allow_threads` GIL release, and registered alongside `fused_sub` in `register()`.
- **`nemopy/_operators.py`** — `__add__`/`__mul__`/`__truediv__` now dispatch to their kernel under the **same guard `__sub__` uses** (`_core._RUST is not None`, `other` is a `_VecBase`, both `float64`), wrapping the result with `_core._apply_type_rules`. `_core.py` is **not** modified (read-only; owned concurrently by #105).

## Tier-2 — fallback retained

These operations exist in NumPy, so this is **Tier-2**: the pure-NumPy fallback (`super().__add__` etc.) is kept when `_rust_core` is absent. **No `ImportError`** is raised (the opposite of the Tier-3 rule in #105 — different tier).

## §5.2 decision — forward operators only

Mirrors the `__sub__` precedent exactly: Rust paths for the **forward** binary operators (`+`, `*`, `/`) only. Reverse (`__radd__`/`__rmul__`/`__rtruediv__`) and in-place (`__iadd__`/…) stay on the NumPy path. Rationale: the kernel returns a *new* array, which is wrong for in-place ops (must mutate and return `self`); reverse ops handle the scalar-/ndarray-left cases the `isinstance(other, _VecBase)` guard wouldn't dispatch anyway. Scope-minimal and consistent with Phase 1.

## Tests (TDD, red → green; add-only in `tests/test_rust_core.py` per §6.6)

- `test_fused_arith_parity` (parametrized over `+`, `*`, `/`): a spy on each kernel proves dispatch actually routes through Rust, and the Rust-path result is asserted equal to the forced-NumPy-fallback path in both value and nemopy result type (ColVec→ColVec, Mat→Mat). The reference is computed with `_RUST` monkeypatched to `None`, which also exercises the retained Tier-2 fallback.
- `test_fused_arith_shape_error_message` (parametrized): calls each kernel directly with mismatched shapes and asserts `ShapeError` with the per-operator message contract.

Both fail with `AttributeError` before implementation (kernels absent) → pass after — genuine red-green.

## Verification

- `pytest tests/` (full suite): **268 passed**.
- `pytest tests/test_rust_core.py`: 10 passed.
- `cargo build --release` / `cargo clippy`: clean — **zero** clippy warnings in `ops.rs` (the 6 repo warnings are pre-existing in `decomp.rs`/`stats.rs`, untouched).
- `ruff check`: passes.

No operator semantics or shape-guard behavior changed (`DESIGN.md` §7.x immutable); no signature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UypCZ1JqKJLM9UQdDeLtSP)_