### PR TITLE
docs(install): document two-mode (pure-Python / Rust) uv install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,55 @@ matrices are constructed column-by-column; arithmetic raises a clear
 
 ## Install
 
+nemopy is not on PyPI yet — install it from the git repository. It requires
+Python `>=3.10` (the repo pins 3.14 via `.python-version`) and is developed
+with [uv](https://docs.astral.sh/uv/). The only hard dependency is NumPy.
+
+There are two modes. **Mode A (pure-Python)** is the default and needs no
+toolchain beyond Python; **Mode B (Rust-enabled)** additionally compiles the
+optional `nemopy._rust_core` extension to unlock the Tier-3 surface.
+
+### Mode A — pure-Python
+
 ```bash
-pip install nemopy                  # core (numpy only)
-pip install "nemopy[pandas]"        # adds pandas Series / DataFrame interop
-pip install "nemopy[dev]"           # adds pytest + sphinx for development
+uv add "git+https://github.com/nster101/nemopy"                  # core (numpy only)
+uv add "nemopy[pandas] @ git+https://github.com/nster101/nemopy" # + pandas interop
+uv add "nemopy[polars] @ git+https://github.com/nster101/nemopy" # + polars interop
+```
+
+This gives you the core types (`ColVec`, `Mat`), shape-guarded arithmetic, the
+Tier-2 decompositions (`svd`, `qr`, `lu`, `cholesky`, `eigh`) and the stats
+helpers — everything that wraps NumPy directly. Tier-3 methods (advanced
+decompositions, elimination, and future LP / network / Markov features) are
+**not** available in this mode: calling one raises a clear `ImportError`
+pointing at the build step, rather than silently falling back.
+
+### Mode B — Rust-enabled
+
+To unlock the Tier-3 surface, build the optional Rust extension after cloning
+the repository. `scripts/build_rust.sh` is the canonical build command (it
+wraps `maturin`):
+
+```bash
+git clone https://github.com/nster101/nemopy
+cd nemopy
+uv sync                             # install Python deps (incl. dev toolchain)
+scripts/build_rust.sh               # compile nemopy._rust_core via maturin
+```
+
+Verify which mode is active:
+
+```bash
+python -c "import nemopy._core as c; print('rust active:', c._RUST is not None)"
+```
+
+Prints `rust active: True` once the extension is built (Mode B) and
+`rust active: False` in pure-Python mode (Mode A).
+
+For development (pytest + sphinx and the full toolchain), use the `dev` extra:
+
+```bash
+uv sync --extra dev
 ```
 
 ## Quick start

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,32 @@ A column-vector-first NumPy wrapper. Vectors are always ``(n, 1)``;
 matrices are constructed column-by-column; arithmetic raises a clear
 ``ShapeError`` when shapes disagree instead of silently broadcasting.
 
+Installation
+------------
+
+nemopy is not on PyPI yet; install it from git. It requires Python ``>=3.10``
+(the repo pins 3.14 via ``.python-version``) and is developed with `uv
+<https://docs.astral.sh/uv/>`_. There are two modes.
+
+**Mode A — pure-Python** (core types, shape-guarded arithmetic, Tier-2
+decompositions ``svd``/``qr``/``lu``/``cholesky``/``eigh``, and stats)::
+
+   uv add "git+https://github.com/nster101/nemopy"
+
+**Mode B — Rust-enabled** unlocks the Tier-3 surface (advanced decompositions,
+elimination, and future LP / network / Markov features). Build the optional
+``nemopy._rust_core`` extension after cloning::
+
+   uv sync
+   scripts/build_rust.sh   # canonical build command (wraps maturin)
+
+Without the extension, Tier-3 methods raise a clear ``ImportError`` instead of
+falling back. Check which mode is active::
+
+   python -c "import nemopy._core as c; print('rust active:', c._RUST is not None)"
+
+See the project ``README`` for the full install guide.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
Closes #118 (DESIGN_APPENDICES.md §20.1/§20.4 tier policy).

## What
Docs-only. Replace the stale install instructions and document both consumption modes.

**`README.md`** (canonical, full):
- Drop the stale `pip install nemopy` (not on PyPI) and Python 3.9 references → uv git-install, Python `>=3.10` (repo pins 3.14 via `.python-version`).
- **Mode A — pure-Python:** `uv add "git+https://github.com/nster101/nemopy"` (+ `pandas`/`polars` extras). Covers core types, shape-guarded arithmetic, Tier-2 decomps (`svd`/`qr`/`lu`/`cholesky`/`eigh`), stats.
- **Mode B — Rust-enabled:** `scripts/build_rust.sh` (canonical build entrypoint from #117; wraps maturin) to compile `nemopy._rust_core` and unlock the Tier-3 surface.
- Note that without the extension Tier-3 raises a clear `ImportError` (post-#105), plus the verify line: `python -c "import nemopy._core as c; print('rust active:', c._RUST is not None)"`.

**`docs/index.rst`** (condensed mirror, per maintainer ruling on #118): a short `Installation` section inserted between the intro and the `.. toctree::` — no new `.rst`, no toctree change.

## Scope / constraints
Docs only. No code, no root `pyproject.toml`, no CI, `tests/`, `scripts/`, or `nemopy/_rust_core/*`. `scripts/build_rust.sh` is referenced (provided by Gauss #117) so this proceeds in parallel.

## Verification
- `sphinx-build -b html` completes (warnings are all pre-existing: intersphinx proxy blocks, `api.rst`/docstring duplicates — none reference `index.rst`).
- `sphinx-build -b doctest`: **zero failures in `index.rst`**; my Installation section uses literal blocks (`::`), so nothing executes. The 72 `examples.rst` failures pre-exist on `main` and are out of scope (§3/§6.6).

## Assumptions
- Canonical install URL `https://github.com/nster101/nemopy` (from #118 `html_url`).
- `scripts/build_rust.sh` exists once #117 lands; referenced as the canonical command per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018HfhmnGe6kRovid6Wsu3zf)_