### PR TITLE
feat(build): reproducible local build &amp; install for nemopy._rust_core (#117)

### DIFF
--- a/scripts/build_rust.sh
+++ b/scripts/build_rust.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# build_rust.sh — reproducible local build/install of nemopy._rust_core (issue #117).
+#
+# Two modes:
+#
+#   1. Default (in-repo development):
+#        scripts/build_rust.sh
+#      Compiles the crate with cargo and copies the compiled extension into the
+#      source tree at nemopy/_rust_core.so, so an editable checkout
+#      (`uv pip install -e .`) can `import nemopy._rust_core` and light up the
+#      Tier-3 surface (nemopy._core._RUST is not None).
+#
+#        cargo build --release --manifest-path nemopy/_rust_core/Cargo.toml
+#        cp nemopy/_rust_core/target/release/lib_rust_core.so nemopy/_rust_core.so
+#
+#   2. Wheel mode (consumer / non-editable install):
+#        scripts/build_rust.sh --wheel
+#      Builds a distributable abi3 wheel with maturin. Install it alongside a
+#      non-editable nemopy (e.g. `uv add "git+https://github.com/.../nemopy"`):
+#        uv pip install <printed wheel path>
+#      Both land in the same site-packages/nemopy/, so the import resolves.
+#
+# Why the default is the in-tree copy and NOT `maturin develop`:
+#   `maturin develop` drops the extension into the active venv's site-packages,
+#   but under an editable nemopy (`pip install -e .`) the `nemopy` package
+#   resolves to the SOURCE TREE, whose `nemopy/_rust_core/` is an empty namespace
+#   directory — so `import nemopy._rust_core` misses the site-packages copy and
+#   _RUST stays None. Copying the .so into the source tree is the path that
+#   actually resolves for in-repo development. (See issue #117.)
+#
+# The crate is built with the abi3-py39 feature, so a single build is usable on
+# CPython >= 3.10 (the nemopy floor).
+#
+# Build artifacts (nemopy/_rust_core.so, target/) are gitignored — never commit them.
+
+set -euo pipefail
+
+# Resolve the repository root so the script works from any working directory.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+MANIFEST="nemopy/_rust_core/Cargo.toml"
+
+if [[ "${1:-}" == "--wheel" ]]; then
+    command -v maturin >/dev/null 2>&1 || {
+        echo "error: maturin not found. Install it with 'uv pip install maturin'." >&2
+        exit 1
+    }
+    echo ">>> Building distributable wheel with maturin..."
+    maturin build --release --manifest-path "${MANIFEST}"
+    echo ">>> Wheel written under nemopy/_rust_core/target/wheels/."
+    echo ">>> Install into a non-editable environment with: uv pip install <wheel>"
+    exit 0
+fi
+
+command -v cargo >/dev/null 2>&1 || {
+    echo "error: cargo not found. Install the Rust toolchain (https://rustup.rs)." >&2
+    exit 1
+}
+
+echo ">>> Building nemopy._rust_core (release)..."
+cargo build --release --manifest-path "${MANIFEST}"
+
+echo ">>> Installing extension into the source tree..."
+cp nemopy/_rust_core/target/release/lib_rust_core.so nemopy/_rust_core.so
+
+echo ">>> Verifying the extension loads..."
+python -c "import nemopy._core as c; assert c._RUST is not None; print('OK: _rust_core', c._RUST.rust_core_version())"
+
+echo ">>> Done. nemopy._rust_core is built and importable."


### PR DESCRIPTION
## What this implements

Closes #117. Adds `scripts/build_rust.sh` — a single, reproducible entrypoint that builds and installs the `nemopy._rust_core` extension so the Tier-3 surface lights up for real-world testing.

**Two modes (per Einstein's authoritative ruling on #117):**

1. **Default (in-repo dev)** — `scripts/build_rust.sh`
   - `cargo build --release --manifest-path nemopy/_rust_core/Cargo.toml`
   - copies `target/release/lib_rust_core.so` → `nemopy/_rust_core.so`
   - verifies `import nemopy._core as c; assert c._RUST is not None`

2. **Wheel (consumer / non-editable)** — `scripts/build_rust.sh --wheel`
   - `maturin build --release` → distributable abi3 wheel, installable next to a non-editable `nemopy`.

## Why `maturin develop` is NOT the default

The brief originally said to wrap `maturin develop --release`. I empirically disproved that path: under an editable `nemopy` (`uv pip install -e .`), `maturin develop` drops the extension into the venv's `site-packages`, but `nemopy` resolves to the **source tree**, whose `nemopy/_rust_core/` is an empty namespace directory. So `import nemopy._rust_core` misses the installed copy and `_RUST` stays `None`. Copying the `.so` into the source tree is the path that actually resolves for in-repo development. Einstein ruled this a justified, evidence-backed correction (recorded on #117), with `maturin build` (wheel) taking over the non-editable consumer role.

## Verification (clean uv venv, pinned Python 3.14, abi3 ≥ 3.10)

```
uv venv --python 3.14
uv pip install -e . pytest
bash scripts/build_rust.sh
python -c "import nemopy._core as c; assert c._RUST is not None"   # passes
python -m pytest tests/test_rust_core.py -q                         # 10 passed
bash scripts/build_rust.sh --wheel                                  # builds cp39-abi3 wheel
```

All checks green: the assert passes and the existing #109 tests run in rust-PRESENT mode.

## Scope / constraints honoured

- **No** edits to root `pyproject.toml` (off-limits), CI (`.github/workflows`), `tests/` (#119, Archimedes), `README`/`docs/` (#118, Euclid), or `lib.rs`/feature `.rs` files.
- `nemopy/_rust_core/Cargo.toml` and `pyproject.toml` build clean as-is — **not modified** (the brief allowed edits "only if needed"; none were).
- Build artifacts (`nemopy/_rust_core.so`, `target/`, wheels) are already gitignored — none committed. `Cargo.lock` unchanged.
- Exact commands documented in the script header (README/docs are #118's scope).

## Assumptions
- Dev setup is editable `nemopy`, which is why the in-tree `.so` is the default.
- No unit tests authored here: `tests/` is Archimedes' (#119); verification for this infra task is the assert + the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6jN9ZH2Rd4WY1JPwiYymM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6jN9ZH2Rd4WY1JPwiYymM)_