### PR TITLE
coord: claim #129 (A[i]→column, Mat.__iter__) + np.generic scope note

### DIFF
--- a/coordination/log/gauss.md
+++ b/coordination/log/gauss.md
@@ -14,3 +14,19 @@ develop` as default — empirically gives _RUST=None under editable install
 uv venv on Python 3.14: assert `_RUST is not None` passes, tests/test_rust_core.py
 10/10 green. No edits to root pyproject/CI/tests/docs/Cargo.toml/lib.rs;
 artifacts gitignored. Newton gates. #91 (LP/IP/MILP) now unblocked — picking up next after #117 lands.
+
+### 2026-06-25T08:23Z — Gauss — claim #129 (A[i]→column i; Mat.__iter__→columns, §6.3)
+Claiming #129 (Einstein-delegated; spec gate cleared — #128 merged @0834709).
+Branch gauss/129-mat-single-index-column. Files MINE: nemopy/_core.py (Mat class) +
+tests/test_core.py (TestMatGetItem). Serial _core.py chain #129→#130→#131→#132 — each
+blocked-until the prior MERGES, so I run them strictly in order, one Newton-gated draft
+PR at a time. Disjoint from Archimedes #111 (decomp.rs/_decompositions.py).
+SCOPE NOTE — maintainer-authorized scope expansion (2026-06-25, /gauss approval): on top
+of the §6.3 integer intercept + Mat.__iter__, I also align Mat.__getitem__'s scalar
+branch from `return float(result)` to the §6.3 code block's `return float(result) if
+isinstance(result, np.generic) else result`. Why: §6.3's code block is the immutable spec
+(CLAUDE.md §1) and this was a latent code/spec textual discrepancy (NOT in #128's diff).
+Behaviour is unchanged on every reachable Mat path (the ndim==0 branch on a float64 Mat
+always yields an np.generic scalar → float()); existing test_mat_getitem_element_returns_float
+guards the live A[i,j]→float path, so no new behaviour is asserted. Declared here + on #129
++ in the PR body so Newton sees the authorization.


### PR DESCRIPTION
Log-only coordination PR (touches `coordination/log/gauss.md` only — gate-exempt, human merges directly).

Claims **#129** (first of the serial `_core.py` chain #129→#130→#131→#132, each blocked-until the prior merges) and **declares a maintainer-authorized scope expansion**: besides the §6.3 integer intercept + `Mat.__iter__`, I align `Mat.__getitem__`'s scalar branch to the §6.3 code block's `return float(result) if isinstance(result, np.generic) else result`. Rationale (behaviour unchanged on all reachable Mat paths; spec-conformance to the immutable §6.3 code block) is recorded in the log entry, on #129, and will be in the feature PR body so Newton sees the authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kfg3PsCPh9dE3UrLGC7Cmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kfg3PsCPh9dE3UrLGC7Cmj)_